### PR TITLE
Add ToString to DataConverter

### DIFF
--- a/encoded/encoded.go
+++ b/encoded/encoded.go
@@ -46,18 +46,9 @@ type (
 	// Temporal support using different DataConverters for different activity/childWorkflow in same workflow.
 	//   2. Activity/Workflow worker that run these activity/childWorkflow, through worker.Options.
 	DataConverter = internal.DataConverter
-
-	// DataStringer can be used in the future to pretty print the input and output of an activity/workflow
-	// that needs to be sent over the wire. This is currently not settable
-	DataStringer = internal.DataStringer
 )
 
 // GetDefaultDataConverter return default data converter used by Temporal worker
 func GetDefaultDataConverter() DataConverter {
 	return internal.DefaultDataConverter
-}
-
-// GetDefaultDataStringer returns data pritty printer
-func GetDefaultDataStringer() DataStringer {
-	return internal.DefaultDataStringer
 }

--- a/encoded/encoded.go
+++ b/encoded/encoded.go
@@ -46,9 +46,18 @@ type (
 	// Temporal support using different DataConverters for different activity/childWorkflow in same workflow.
 	//   2. Activity/Workflow worker that run these activity/childWorkflow, through worker.Options.
 	DataConverter = internal.DataConverter
+
+	// DataStringer can be used in the future to pretty print the input and output of an activity/workflow
+	// that needs to be sent over the wire. This is currently not settable
+	DataStringer = internal.DataStringer
 )
 
 // GetDefaultDataConverter return default data converter used by Temporal worker
 func GetDefaultDataConverter() DataConverter {
+	return internal.DefaultDataConverter
+}
+
+// GetDefaultDataStringer returns data pritty printer
+func GetDefaultDataStringer() DataStringer {
 	return internal.DefaultDataConverter
 }

--- a/encoded/encoded.go
+++ b/encoded/encoded.go
@@ -59,5 +59,5 @@ func GetDefaultDataConverter() DataConverter {
 
 // GetDefaultDataStringer returns data pritty printer
 func GetDefaultDataStringer() DataStringer {
-	return internal.DefaultDataConverter
+	return internal.DefaultDataStringer
 }

--- a/internal/encoded.go
+++ b/internal/encoded.go
@@ -81,9 +81,6 @@ type (
 		ToPrettyStrings(input *commonpb.Payloads) ([]string, error)
 	}
 
-	// DataStringer can be used by framework to print human readable data
-	// This interface is currently not settable
-
 	defaultDataConverter struct {
 	}
 )

--- a/internal/encoded.go
+++ b/internal/encoded.go
@@ -76,28 +76,21 @@ type (
 		// FromPayloads implements conversion of an array of values of different types.
 		// Useful for deserializing arguments of function invocations.
 		FromPayloads(input *commonpb.Payloads, valuePtrs ...interface{}) error
+
+		// ToPrettyStrings converts the Payloads object into human readable strings
+		ToPrettyStrings(input *commonpb.Payloads) ([]string, error)
 	}
 
 	// DataStringer can be used by framework to print human readable data
 	// This interface is currently not settable
-	DataStringer interface {
-		// ToPrettyStrings converts payloads into human readable strings
-		ToPrettyStrings(input *commonpb.Payloads) ([]string, error)
-	}
 
 	defaultDataConverter struct {
-	}
-
-	defaultDataStringer struct {
 	}
 )
 
 var (
 	// DefaultDataConverter is default data converter used by Temporal worker.
 	DefaultDataConverter = &defaultDataConverter{}
-
-	// DefaultDataStringer is the default data stringer
-	DefaultDataStringer = &defaultDataStringer{}
 
 	// ErrMetadataIsNotSet is returned when metadata is not set.
 	ErrMetadataIsNotSet = errors.New("metadata is not set")
@@ -116,10 +109,6 @@ var (
 // getDefaultDataConverter return default data converter used by Temporal worker.
 func getDefaultDataConverter() DataConverter {
 	return DefaultDataConverter
-}
-
-func getDefaultDataStringer() DataStringer {
-	return DefaultDataStringer
 }
 
 func (dc *defaultDataConverter) ToPayloads(values ...interface{}) (*commonpb.Payloads, error) {
@@ -159,7 +148,7 @@ func (dc *defaultDataConverter) FromPayloads(payloads *commonpb.Payloads, valueP
 	return nil
 }
 
-func (dc *defaultDataConverter) ToPayload(value interface{}) (*commonpb.Payload, error) {
+func (*defaultDataConverter) ToPayload(value interface{}) (*commonpb.Payload, error) {
 	var payload *commonpb.Payload
 	if bytes, isByteSlice := value.([]byte); isByteSlice {
 		payload = &commonpb.Payload{
@@ -184,7 +173,7 @@ func (dc *defaultDataConverter) ToPayload(value interface{}) (*commonpb.Payload,
 	return payload, nil
 }
 
-func (dc *defaultDataConverter) FromPayload(payload *commonpb.Payload, valuePtr interface{}) error {
+func (*defaultDataConverter) FromPayload(payload *commonpb.Payload, valuePtr interface{}) error {
 	if payload == nil {
 		return nil
 	}
@@ -221,7 +210,7 @@ func decodeEncodingJSON(payload *commonpb.Payload, valuePtr interface{}) error {
 	return nil
 }
 
-func (ds *defaultDataStringer) ToPrettyStrings(payloads *commonpb.Payloads) ([]string, error) {
+func (*defaultDataConverter) ToPrettyStrings(payloads *commonpb.Payloads) ([]string, error) {
 	if payloads == nil {
 		return nil, nil
 	}

--- a/internal/encoded.go
+++ b/internal/encoded.go
@@ -77,8 +77,8 @@ type (
 		// Useful for deserializing arguments of function invocations.
 		FromPayloads(input *commonpb.Payloads, valuePtrs ...interface{}) error
 
-		// ToPrettyStrings converts the Payloads object into human readable strings
-		ToPrettyStrings(input *commonpb.Payloads) ([]string, error)
+		// ToStrings converts the Payloads object into human readable strings
+		ToStrings(input *commonpb.Payloads) ([]string, error)
 	}
 
 	defaultDataConverter struct {
@@ -207,14 +207,14 @@ func decodeEncodingJSON(payload *commonpb.Payload, valuePtr interface{}) error {
 	return nil
 }
 
-func (*defaultDataConverter) ToPrettyStrings(payloads *commonpb.Payloads) ([]string, error) {
+func (*defaultDataConverter) ToStrings(payloads *commonpb.Payloads) ([]string, error) {
 	if payloads == nil {
 		return nil, nil
 	}
 
 	var result []string
 	for i, payload := range payloads.GetPayloads() {
-		payloadAsStr, err := toPrettyString(payload)
+		payloadAsStr, err := toString(payload)
 		if err != nil {
 			return result, fmt.Errorf("payload item %d: %w", i, err)
 		}
@@ -237,7 +237,7 @@ func getEncoding(payload *commonpb.Payload) (string, error) {
 	return "", ErrEncodingIsNotSet
 }
 
-func toPrettyString(payload *commonpb.Payload) (string, error) {
+func toString(payload *commonpb.Payload) (string, error) {
 	result := ""
 
 	if payload == nil {

--- a/internal/encoded.go
+++ b/internal/encoded.go
@@ -87,11 +87,17 @@ type (
 
 	defaultDataConverter struct {
 	}
+
+	defaultDataStringer struct {
+	}
 )
 
 var (
 	// DefaultDataConverter is default data converter used by Temporal worker.
 	DefaultDataConverter = &defaultDataConverter{}
+
+	// DefaultDataStringer is the default data stringer
+	DefaultDataStringer = &defaultDataStringer{}
 
 	// ErrMetadataIsNotSet is returned when metadata is not set.
 	ErrMetadataIsNotSet = errors.New("metadata is not set")
@@ -110,6 +116,10 @@ var (
 // getDefaultDataConverter return default data converter used by Temporal worker.
 func getDefaultDataConverter() DataConverter {
 	return DefaultDataConverter
+}
+
+func getDefaultDataStringer() DataStringer {
+	return DefaultDataStringer
 }
 
 func (dc *defaultDataConverter) ToPayloads(values ...interface{}) (*commonpb.Payloads, error) {
@@ -211,7 +221,7 @@ func decodeEncodingJSON(payload *commonpb.Payload, valuePtr interface{}) error {
 	return nil
 }
 
-func (dc *defaultDataConverter) ToPrettyStrings(payloads *commonpb.Payloads) ([]string, error) {
+func (ds *defaultDataStringer) ToPrettyStrings(payloads *commonpb.Payloads) ([]string, error) {
 	if payloads == nil {
 		return nil, nil
 	}

--- a/internal/encoded_test.go
+++ b/internal/encoded_test.go
@@ -100,13 +100,12 @@ func TestDefaultDataConverter(t *testing.T) {
 func testDataStringerFunction(
 	t *testing.T,
 	dc DataConverter,
-	ds DataStringer,
 	args ...interface{},
 ) []string {
 	input, err := dc.ToPayloads(args...)
 	require.NoError(t, err, err)
 
-	prettyStrings, err := getDefaultDataStringer().ToPrettyStrings(input)
+	prettyStrings, err := dc.ToPrettyStrings(input)
 	require.NoError(t, err, err)
 
 	return prettyStrings
@@ -115,7 +114,6 @@ func testDataStringerFunction(
 func TestDataStringer(t *testing.T) {
 	t.Parallel()
 	dc := getDefaultDataConverter()
-	ds := getDefaultDataStringer()
 
 	testStruct := struct {
 		A string
@@ -125,7 +123,7 @@ func TestDataStringer(t *testing.T) {
 		B: 3,
 	}
 
-	r := testDataStringerFunction(t, dc, ds,
+	r := testDataStringerFunction(t, dc,
 		[]byte("test"),
 		[]string{"hello", "world"},
 		"hello world",

--- a/internal/encoded_test.go
+++ b/internal/encoded_test.go
@@ -97,11 +97,16 @@ func TestDefaultDataConverter(t *testing.T) {
 	})
 }
 
-func testDataStringerFunction(t *testing.T, dc DataConverter, args ...interface{}) []string {
+func testDataStringerFunction(
+	t *testing.T,
+	dc DataConverter,
+	ds DataStringer,
+	args ...interface{},
+) []string {
 	input, err := dc.ToPayloads(args...)
 	require.NoError(t, err, err)
 
-	prettyStrings, err := DefaultDataStringer.ToPrettyStrings(input)
+	prettyStrings, err := getDefaultDataStringer().ToPrettyStrings(input)
 	require.NoError(t, err, err)
 
 	return prettyStrings
@@ -110,6 +115,8 @@ func testDataStringerFunction(t *testing.T, dc DataConverter, args ...interface{
 func TestDataStringer(t *testing.T) {
 	t.Parallel()
 	dc := getDefaultDataConverter()
+	ds := getDefaultDataStringer()
+
 	testStruct := struct {
 		A string
 		B int
@@ -118,7 +125,7 @@ func TestDataStringer(t *testing.T) {
 		B: 3,
 	}
 
-	r := testDataStringerFunction(t, dc,
+	r := testDataStringerFunction(t, dc, ds,
 		[]byte("test"),
 		[]string{"hello", "world"},
 		"hello world",

--- a/internal/encoded_test.go
+++ b/internal/encoded_test.go
@@ -97,7 +97,7 @@ func TestDefaultDataConverter(t *testing.T) {
 	})
 }
 
-func testToPrettyStringsFunction(
+func testToStringsFunction(
 	t *testing.T,
 	dc DataConverter,
 	args ...interface{},
@@ -105,13 +105,13 @@ func testToPrettyStringsFunction(
 	input, err := dc.ToPayloads(args...)
 	require.NoError(t, err, err)
 
-	prettyStrings, err := dc.ToPrettyStrings(input)
+	strings, err := dc.ToStrings(input)
 	require.NoError(t, err, err)
 
-	return prettyStrings
+	return strings
 }
 
-func TestToPrettyStrings(t *testing.T) {
+func TestToStrings(t *testing.T) {
 	t.Parallel()
 	dc := getDefaultDataConverter()
 
@@ -123,7 +123,7 @@ func TestToPrettyStrings(t *testing.T) {
 		B: 3,
 	}
 
-	r := testToPrettyStringsFunction(t, dc,
+	got := testToStringsFunction(t, dc,
 		[]byte("test"),
 		[]string{"hello", "world"},
 		"hello world",
@@ -138,7 +138,7 @@ func TestToPrettyStrings(t *testing.T) {
 		"map[A:hi B:3]",
 	}
 
-	require.Equal(t, want, r)
+	require.Equal(t, want, got)
 }
 
 // testDataConverter implements encoded.DataConverter using gob
@@ -212,10 +212,10 @@ func (dc *testDataConverter) FromPayload(payload *commonpb.Payload, valuePtr int
 	return nil
 }
 
-func (dc *testDataConverter) ToPrettyStrings(payloads *commonpb.Payloads) ([]string, error) {
+func (dc *testDataConverter) ToStrings(payloads *commonpb.Payloads) ([]string, error) {
 	var result []string
 	for i, payload := range payloads.GetPayloads() {
-		payloadAsStr, err := toPrettyStringTestHelper(payload)
+		payloadAsStr, err := toStringTestHelper(payload)
 
 		if err != nil {
 			return result, fmt.Errorf("args[%d]: %w", i, err)
@@ -227,7 +227,7 @@ func (dc *testDataConverter) ToPrettyStrings(payloads *commonpb.Payloads) ([]str
 	return result, nil
 }
 
-func toPrettyStringTestHelper(payload *commonpb.Payload) (string, error) {
+func toStringTestHelper(payload *commonpb.Payload) (string, error) {
 	encoding, ok := payload.GetMetadata()[metadataEncoding]
 
 	if !ok {

--- a/internal/encoded_test.go
+++ b/internal/encoded_test.go
@@ -97,6 +97,45 @@ func TestDefaultDataConverter(t *testing.T) {
 	})
 }
 
+func testDataConverterPrettyPrintFunction(t *testing.T, dc DataConverter, args ...interface{}) []string {
+	input, err := dc.ToPayloads(args...)
+	require.NoError(t, err, err)
+
+	prettyStrings, err := dc.ToPrettyStrings(input)
+	require.NoError(t, err, err)
+
+	return prettyStrings
+}
+
+func TestDataConverterPrettyPrint(t *testing.T) {
+	t.Parallel()
+	dc := getDefaultDataConverter()
+	testStruct := struct {
+		A string
+		B int
+	}{
+		A: "hi",
+		B: 3,
+	}
+
+	r := testDataConverterPrettyPrintFunction(t, dc,
+		[]byte("test"),
+		[]string{"hello", "world"},
+		"hello world",
+		42,
+		testStruct)
+
+	want := []string{
+		"dGVzdA",
+		"[hello world]",
+		"hello world",
+		"42",
+		"map[A:hi B:3]",
+	}
+
+	require.Equal(t, want, r)
+}
+
 // testDataConverter implements encoded.DataConverter using gob
 type testDataConverter struct{}
 
@@ -166,6 +205,42 @@ func (dc *testDataConverter) FromPayload(payload *commonpb.Payload, valuePtr int
 	}
 
 	return nil
+}
+
+func (dc *testDataConverter) ToPrettyStrings(payloads *commonpb.Payloads) ([]string, error) {
+	var result []string
+	for i, payload := range payloads.GetPayloads() {
+		payloadAsStr, err := toPrettyStringTestHelper(payload)
+
+		if err != nil {
+			return result, fmt.Errorf("args[%d]: %w", i, err)
+		}
+
+		result = append(result, payloadAsStr)
+	}
+
+	return result, nil
+}
+
+func toPrettyStringTestHelper(payload *commonpb.Payload) (string, error) {
+	encoding, ok := payload.GetMetadata()[metadataEncoding]
+
+	if !ok {
+		return "", ErrEncodingIsNotSet
+	}
+
+	e := string(encoding)
+	if e == metadataEncodingGob {
+		var byteSlice []byte
+		dec := gob.NewDecoder(bytes.NewBuffer(payload.GetData()))
+		if err := dec.Decode(&byteSlice); err != nil {
+			return "", fmt.Errorf("%w: %v", ErrUnableToDecodeGob, err)
+		}
+	} else {
+		return "", fmt.Errorf("encoding %q: %w", e, ErrEncodingIsNotSupported)
+	}
+
+	return "", nil
 }
 
 func TestDecodeArg(t *testing.T) {

--- a/internal/encoded_test.go
+++ b/internal/encoded_test.go
@@ -101,7 +101,7 @@ func testDataStringerFunction(t *testing.T, dc DataConverter, args ...interface{
 	input, err := dc.ToPayloads(args...)
 	require.NoError(t, err, err)
 
-	prettyStrings, err := DefaultDataConverter.ToPrettyStrings(input)
+	prettyStrings, err := DefaultDataStringer.ToPrettyStrings(input)
 	require.NoError(t, err, err)
 
 	return prettyStrings

--- a/internal/encoded_test.go
+++ b/internal/encoded_test.go
@@ -97,7 +97,7 @@ func TestDefaultDataConverter(t *testing.T) {
 	})
 }
 
-func testDataStringerFunction(
+func testToPrettyStringFunction(
 	t *testing.T,
 	dc DataConverter,
 	args ...interface{},
@@ -111,7 +111,7 @@ func testDataStringerFunction(
 	return prettyStrings
 }
 
-func TestDataStringer(t *testing.T) {
+func TestToPrettyString(t *testing.T) {
 	t.Parallel()
 	dc := getDefaultDataConverter()
 
@@ -123,7 +123,7 @@ func TestDataStringer(t *testing.T) {
 		B: 3,
 	}
 
-	r := testDataStringerFunction(t, dc,
+	r := testToPrettyStringFunction(t, dc,
 		[]byte("test"),
 		[]string{"hello", "world"},
 		"hello world",

--- a/internal/encoded_test.go
+++ b/internal/encoded_test.go
@@ -97,17 +97,17 @@ func TestDefaultDataConverter(t *testing.T) {
 	})
 }
 
-func testDataConverterPrettyPrintFunction(t *testing.T, dc DataConverter, args ...interface{}) []string {
+func testDataStringerFunction(t *testing.T, dc DataConverter, args ...interface{}) []string {
 	input, err := dc.ToPayloads(args...)
 	require.NoError(t, err, err)
 
-	prettyStrings, err := dc.ToPrettyStrings(input)
+	prettyStrings, err := DefaultDataConverter.ToPrettyStrings(input)
 	require.NoError(t, err, err)
 
 	return prettyStrings
 }
 
-func TestDataConverterPrettyPrint(t *testing.T) {
+func TestDataStringer(t *testing.T) {
 	t.Parallel()
 	dc := getDefaultDataConverter()
 	testStruct := struct {
@@ -118,7 +118,7 @@ func TestDataConverterPrettyPrint(t *testing.T) {
 		B: 3,
 	}
 
-	r := testDataConverterPrettyPrintFunction(t, dc,
+	r := testDataStringerFunction(t, dc,
 		[]byte("test"),
 		[]string{"hello", "world"},
 		"hello world",

--- a/internal/encoded_test.go
+++ b/internal/encoded_test.go
@@ -97,7 +97,7 @@ func TestDefaultDataConverter(t *testing.T) {
 	})
 }
 
-func testToPrettyStringFunction(
+func testToPrettyStringsFunction(
 	t *testing.T,
 	dc DataConverter,
 	args ...interface{},
@@ -111,7 +111,7 @@ func testToPrettyStringFunction(
 	return prettyStrings
 }
 
-func TestToPrettyString(t *testing.T) {
+func TestToPrettyStrings(t *testing.T) {
 	t.Parallel()
 	dc := getDefaultDataConverter()
 
@@ -123,7 +123,7 @@ func TestToPrettyString(t *testing.T) {
 		B: 3,
 	}
 
-	r := testToPrettyStringFunction(t, dc,
+	r := testToPrettyStringsFunction(t, dc,
 		[]byte("test"),
 		[]string{"hello", "world"},
 		"hello world",


### PR DESCRIPTION
Adds `ToString` to `DataConverter` interface and `defaultDataConverter` so that a caller can get a "prettified" version of the `Payloads` as `string`, which can be useful for things like looking at heartbeat details and logging.