### PR TITLE
Extract InterruptCh func

### DIFF
--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -30,9 +30,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/uber-go/tally"
@@ -159,12 +157,6 @@ func awaitWaitGroup(wg *sync.WaitGroup, timeout time.Duration) bool {
 	case <-time.After(timeout):
 		return false
 	}
-}
-
-func getKillSignal() <-chan os.Signal {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	return c
 }
 
 // getMetricsScopeForActivity return properly tagged tally scope for activity

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -161,6 +161,7 @@ func awaitWaitGroup(wg *sync.WaitGroup, timeout time.Duration) bool {
 	}
 }
 
+// InterruptCh returns channel which will get data when system receives interrupt signal. Pass it to worker.Run() func to stop worker with Ctrl+C.
 func InterruptCh() <-chan interface{} {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -35,13 +35,11 @@ import (
 	"io"
 	"math"
 	"os"
-	"os/signal"
 	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -1069,20 +1067,6 @@ func (aw *AggregatedWorker) Run(ch <-chan interface{}) error {
 	}
 
 	return nil
-}
-
-func (aw *AggregatedWorker) StopSignal() <-chan interface{} {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-
-	ret := make(chan interface{}, 1)
-	go func() {
-		s := <-c
-		ret <- s
-		close(ret)
-	}()
-
-	return ret
 }
 
 // Stop the worker.

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -347,15 +347,6 @@ func (bw *baseWorker) processTask(task interface{}) {
 	}
 }
 
-func (bw *baseWorker) Run() {
-	bw.Start()
-	d := <-getKillSignal()
-	traceLog(func() {
-		bw.logger.Info("Worker has been killed", zap.String("Signal", d.String()))
-	})
-	bw.Stop()
-}
-
 // Stop is a blocking call and cleans up all the resources associated with worker.
 func (bw *baseWorker) Stop() {
 	if !bw.isWorkerStarted {

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -982,7 +982,7 @@ func (s *internalWorkerTestSuite) TestCreateWorkerRun() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_ = worker.Run(worker.StopSignal())
+		_ = worker.Run(InterruptCh())
 	}()
 	time.Sleep(time.Millisecond * 200)
 	p, err := os.FindProcess(os.Getpid())
@@ -1026,7 +1026,7 @@ func (s *internalWorkerTestSuite) TestWorkerStartFailsWithInvalidNamespace() {
 			err := worker.Start()
 			assert.Error(t, err, "worker.start() MUST fail when namespace is invalid")
 			errC := make(chan error)
-			go func() { errC <- worker.Run(worker.StopSignal()) }()
+			go func() { errC <- worker.Run(InterruptCh()) }()
 			select {
 			case e := <-errC:
 				assert.Error(t, e, "worker.Run() MUST fail when namespace is invalid")

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -982,7 +982,7 @@ func (s *internalWorkerTestSuite) TestCreateWorkerRun() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_ = worker.Run()
+		_ = worker.Run(worker.StopSignal())
 	}()
 	time.Sleep(time.Millisecond * 200)
 	p, err := os.FindProcess(os.Getpid())
@@ -1026,7 +1026,7 @@ func (s *internalWorkerTestSuite) TestWorkerStartFailsWithInvalidNamespace() {
 			err := worker.Start()
 			assert.Error(t, err, "worker.start() MUST fail when namespace is invalid")
 			errC := make(chan error)
-			go func() { errC <- worker.Run() }()
+			go func() { errC <- worker.Run(worker.StopSignal()) }()
 			select {
 			case e := <-errC:
 				assert.Error(t, e, "worker.Run() MUST fail when namespace is invalid")

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -119,8 +119,6 @@ type (
 		Run(ch <-chan interface{}) error
 		// Stop the worker.
 		Stop()
-
-		StopSignal() <-chan interface{}
 	}
 
 	// WorkflowReplayer supports replaying a workflow from its event history.
@@ -231,4 +229,8 @@ func SetStickyWorkflowCacheSize(cacheSize int) {
 // On another hand, once the binary is marked as bad, the bad binary cannot poll workflow queue and make any progress any more.
 func SetBinaryChecksum(checksum string) {
 	internal.SetBinaryChecksum(checksum)
+}
+
+func InterruptCh() <-chan interface{} {
+	return internal.InterruptCh()
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -114,7 +114,10 @@ type (
 
 		// Start the worker in a non-blocking fashion.
 		Start() error
-		// Run the worker in a blocking fashion. Stop the worker when process is killed with SIGINT or SIGTERM.
+		// Run the worker in a blocking fashion. Stop the worker when ch receives data.
+		// Pass worker.InterruptCh() to stop the worker with SIGINT or SIGTERM.
+		// Pass nil to stop the worker with external Stop() call.
+		// Pass any other `<-chan interface{}` and Run will wait for data from that channel.
 		// Returns error only if worker fails to start.
 		Run(ch <-chan interface{}) error
 		// Stop the worker.
@@ -231,6 +234,7 @@ func SetBinaryChecksum(checksum string) {
 	internal.SetBinaryChecksum(checksum)
 }
 
+// InterruptCh returns channel which will get data when system receives interrupt signal. Pass it to worker.Run() func to stop worker with Ctrl+C.
 func InterruptCh() <-chan interface{} {
 	return internal.InterruptCh()
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -116,9 +116,11 @@ type (
 		Start() error
 		// Run the worker in a blocking fashion. Stop the worker when process is killed with SIGINT or SIGTERM.
 		// Returns error only if worker fails to start.
-		Run() error
+		Run(ch <-chan interface{}) error
 		// Stop the worker.
 		Stop()
+
+		StopSignal() <-chan interface{}
 	}
 
 	// WorkflowReplayer supports replaying a workflow from its event history.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -114,12 +114,14 @@ type (
 
 		// Start the worker in a non-blocking fashion.
 		Start() error
-		// Run the worker in a blocking fashion. Stop the worker when ch receives data.
+
+		// Run the worker in a blocking fashion. Stop the worker when interruptCh receives signal.
 		// Pass worker.InterruptCh() to stop the worker with SIGINT or SIGTERM.
 		// Pass nil to stop the worker with external Stop() call.
-		// Pass any other `<-chan interface{}` and Run will wait for data from that channel.
+		// Pass any other `<-chan interface{}` and Run will wait for signal from that channel.
 		// Returns error only if worker fails to start.
-		Run(ch <-chan interface{}) error
+		Run(interruptCh <-chan interface{}) error
+
 		// Stop the worker.
 		Stop()
 	}
@@ -132,7 +134,6 @@ type (
 	// It is important to maintain backwards compatibility through use of workflow.GetVersion
 	// to ensure that new deployments are not going to break open workflows.
 	WorkflowReplayer interface {
-
 		// RegisterWorkflow registers workflow that is going to be replayed
 		RegisterWorkflow(w interface{})
 
@@ -234,7 +235,7 @@ func SetBinaryChecksum(checksum string) {
 	internal.SetBinaryChecksum(checksum)
 }
 
-// InterruptCh returns channel which will get data when system receives interrupt signal. Pass it to worker.Run() func to stop worker with Ctrl+C.
+// InterruptCh returns channel which will get data when system receives interrupt signal from OS. Pass it to worker.Run() func to stop worker with Ctrl+C.
 func InterruptCh() <-chan interface{} {
 	return internal.InterruptCh()
 }


### PR DESCRIPTION
Following code block:
```
w := worker.New(c, "hello-world", worker.Options{})
err = w.Run()
```
becomes:
```
w := worker.New(c, "hello-world", worker.Options{})
err = w.Run(worker.InterruptCh())
```
and it will wait for `Ctrl+C` or
```
w := worker.New(c, "hello-world", worker.Options{})
err = w.Run(nil)
```
and it will wait for `w.Stop()` call.

Or you can pass any `<-chan interface{}` and `Run` will stop the worker as soon as there is a signal in the channel.

Closes #94.