### PR TITLE
Use DefaultLogger instead of NopLogger in WorkflowReplayer funcs

### DIFF
--- a/client/logger.go
+++ b/client/logger.go
@@ -34,7 +34,4 @@ type (
 
 	// WithLogger is an interface that prepend every log entry with keyvals.
 	WithLogger = log.WithLogger
-
-	// DefaultLogger is Logger implementation on top of standart log.Logger. It is used if logger is not specified.
-	DefaultLogger = log.DefaultLogger
 )

--- a/client/logger.go
+++ b/client/logger.go
@@ -34,4 +34,7 @@ type (
 
 	// WithLogger is an interface that prepend every log entry with keyvals.
 	WithLogger = log.WithLogger
+
+	// DefaultLogger is Logger implementation on top of standart log.Logger. It is used if logger is not specified.
+	DefaultLogger = log.DefaultLogger
 )

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1106,7 +1106,7 @@ func (aw *WorkflowReplayer) RegisterWorkflowWithOptions(w interface{}, options R
 // The logger is an optional parameter. Defaults to the noop logger.
 func (aw *WorkflowReplayer) ReplayWorkflowHistory(logger log.Logger, history *historypb.History) error {
 	if logger == nil {
-		logger = log.NewNopLogger()
+		logger = log.NewDefaultLogger()
 	}
 
 	controller := gomock.NewController(log.NewTestReporter(logger))
@@ -1134,7 +1134,7 @@ func (aw *WorkflowReplayer) ReplayPartialWorkflowHistoryFromJSONFile(loger log.L
 	}
 
 	if loger == nil {
-		loger = log.NewNopLogger()
+		loger = log.NewDefaultLogger()
 	}
 
 	controller := gomock.NewController(log.NewTestReporter(loger))
@@ -1146,7 +1146,7 @@ func (aw *WorkflowReplayer) ReplayPartialWorkflowHistoryFromJSONFile(loger log.L
 // ReplayWorkflowExecution replays workflow execution loading it from Temporal service.
 func (aw *WorkflowReplayer) ReplayWorkflowExecution(ctx context.Context, service workflowservice.WorkflowServiceClient, logger log.Logger, namespace string, execution WorkflowExecution) error {
 	if logger == nil {
-		logger = log.NewNopLogger()
+		logger = log.NewDefaultLogger()
 	}
 
 	sharedExecution := &commonpb.WorkflowExecution{


### PR DESCRIPTION
If logger is not passed to `WorkflowReplayer` funcs, `DefaultLogger` will be used.