### PR TITLE
Move log interface from internal directory

### DIFF
--- a/activity/activity.go
+++ b/activity/activity.go
@@ -30,7 +30,7 @@ import (
 	"github.com/uber-go/tally"
 
 	"go.temporal.io/sdk/internal"
-	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/log"
 )
 
 type (

--- a/activity/activity.go
+++ b/activity/activity.go
@@ -30,7 +30,7 @@ import (
 	"github.com/uber-go/tally"
 
 	"go.temporal.io/sdk/internal"
-	"go.temporal.io/sdk/internal/log"
+	ilog "go.temporal.io/sdk/internal/log"
 )
 
 type (

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -35,6 +35,7 @@ import (
 
 	"go.temporal.io/sdk/internal/converter"
 	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 type (
@@ -171,7 +172,7 @@ func GetHeartbeatDetails(ctx context.Context, d ...interface{}) error {
 }
 
 // GetActivityLogger returns a logger that can be used in activity
-func GetActivityLogger(ctx context.Context) log.Logger {
+func GetActivityLogger(ctx context.Context) tlog.Logger {
 	env := getActivityEnv(ctx)
 	return env.logger
 }
@@ -238,7 +239,7 @@ func WithActivityTask(
 	task *workflowservice.PollActivityTaskQueueResponse,
 	taskQueue string,
 	invoker ServiceInvoker,
-	logger log.Logger,
+	logger tlog.Logger,
 	scope tally.Scope,
 	dataConverter converter.DataConverter,
 	workerStopChannel <-chan struct{},

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -34,8 +34,8 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
-	tlog "go.temporal.io/sdk/log"
+	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/log"
 )
 
 type (
@@ -172,7 +172,7 @@ func GetHeartbeatDetails(ctx context.Context, d ...interface{}) error {
 }
 
 // GetActivityLogger returns a logger that can be used in activity
-func GetActivityLogger(ctx context.Context) tlog.Logger {
+func GetActivityLogger(ctx context.Context) log.Logger {
 	env := getActivityEnv(ctx)
 	return env.logger
 }
@@ -239,7 +239,7 @@ func WithActivityTask(
 	task *workflowservice.PollActivityTaskQueueResponse,
 	taskQueue string,
 	invoker ServiceInvoker,
-	logger tlog.Logger,
+	logger log.Logger,
 	scope tally.Scope,
 	dataConverter converter.DataConverter,
 	workerStopChannel <-chan struct{},
@@ -261,7 +261,7 @@ func WithActivityTask(
 		deadline = startToCloseDeadline
 	}
 
-	logger = log.With(logger,
+	logger = ilog.With(logger,
 		tagActivityID, task.ActivityId,
 		tagActivityType, task.ActivityType.Name,
 		tagWorkflowType, task.WorkflowType.Name,

--- a/internal/client.go
+++ b/internal/client.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/converter"
 	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 const (
@@ -327,7 +328,7 @@ type (
 
 		// Optional: Logger framework can use to log.
 		// default: default logger provided.
-		Logger log.Logger
+		Logger tlog.Logger
 
 		// Optional: Metrics to be reported.
 		// Default metrics are Prometheus compatible but default separator (.) should be replaced with some other character:

--- a/internal/client.go
+++ b/internal/client.go
@@ -38,8 +38,8 @@ import (
 
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
-	tlog "go.temporal.io/sdk/log"
+	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/log"
 )
 
 const (
@@ -328,7 +328,7 @@ type (
 
 		// Optional: Logger framework can use to log.
 		// default: default logger provided.
-		Logger tlog.Logger
+		Logger log.Logger
 
 		// Optional: Metrics to be reported.
 		// Default metrics are Prometheus compatible but default separator (.) should be replaced with some other character:
@@ -528,7 +528,7 @@ func NewClient(options ClientOptions) (Client, error) {
 	}
 
 	if options.Logger == nil {
-		options.Logger = log.NewDefaultLogger()
+		options.Logger = ilog.NewDefaultLogger()
 		options.Logger.Info("No logger configured for temporal client. Created default one.")
 	}
 

--- a/internal/cmd/dummy/dummy.go
+++ b/internal/cmd/dummy/dummy.go
@@ -29,6 +29,7 @@ import (
 	_ "go.temporal.io/sdk/activity"
 	_ "go.temporal.io/sdk/client"
 	_ "go.temporal.io/sdk/converter"
+	_ "go.temporal.io/sdk/log"
 	_ "go.temporal.io/sdk/temporal"
 	_ "go.temporal.io/sdk/testsuite"
 	_ "go.temporal.io/sdk/worker"

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -38,7 +38,7 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	ilog "go.temporal.io/sdk/internal/log"
 )
 
 const (
@@ -105,7 +105,7 @@ func Test_GenericGoError(t *testing.T) {
 func Test_ActivityNotRegistered(t *testing.T) {
 	registeredActivityFn, unregisteredActivitFn := "RegisteredActivity", "UnregisteredActivityFn"
 	s := &WorkflowTestSuite{}
-	s.SetLogger(log.NewNopLogger())
+	s.SetLogger(ilog.NewNopLogger())
 	env := s.NewTestActivityEnvironment()
 	env.RegisterActivityWithOptions(func() error { return nil }, RegisterActivityOptions{Name: registeredActivityFn})
 	_, err := env.ExecuteActivity(unregisteredActivitFn)

--- a/internal/interceptors.go
+++ b/internal/interceptors.go
@@ -30,7 +30,7 @@ import (
 	"github.com/uber-go/tally"
 
 	"go.temporal.io/sdk/internal/converter"
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 // WorkflowInterceptor is used to create a single link in the interceptor chain
@@ -70,7 +70,7 @@ type WorkflowOutboundCallsInterceptor interface {
 	ExecuteLocalActivity(ctx Context, activityType string, args ...interface{}) Future
 	ExecuteChildWorkflow(ctx Context, childWorkflowType string, args ...interface{}) ChildWorkflowFuture
 	GetWorkflowInfo(ctx Context) *WorkflowInfo
-	GetLogger(ctx Context) tlog.Logger
+	GetLogger(ctx Context) log.Logger
 	GetMetricsScope(ctx Context) tally.Scope
 	Now(ctx Context) time.Time
 	NewTimer(ctx Context, d time.Duration) Future
@@ -139,7 +139,7 @@ func (t *WorkflowOutboundCallsInterceptorBase) GetWorkflowInfo(ctx Context) *Wor
 }
 
 // GetLogger forwards to t.Next
-func (t *WorkflowOutboundCallsInterceptorBase) GetLogger(ctx Context) tlog.Logger {
+func (t *WorkflowOutboundCallsInterceptorBase) GetLogger(ctx Context) log.Logger {
 	return t.Next.GetLogger(ctx)
 }
 

--- a/internal/interceptors.go
+++ b/internal/interceptors.go
@@ -30,7 +30,7 @@ import (
 	"github.com/uber-go/tally"
 
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 // WorkflowInterceptor is used to create a single link in the interceptor chain
@@ -70,7 +70,7 @@ type WorkflowOutboundCallsInterceptor interface {
 	ExecuteLocalActivity(ctx Context, activityType string, args ...interface{}) Future
 	ExecuteChildWorkflow(ctx Context, childWorkflowType string, args ...interface{}) ChildWorkflowFuture
 	GetWorkflowInfo(ctx Context) *WorkflowInfo
-	GetLogger(ctx Context) log.Logger
+	GetLogger(ctx Context) tlog.Logger
 	GetMetricsScope(ctx Context) tally.Scope
 	Now(ctx Context) time.Time
 	NewTimer(ctx Context, d time.Duration) Future
@@ -139,7 +139,7 @@ func (t *WorkflowOutboundCallsInterceptorBase) GetWorkflowInfo(ctx Context) *Wor
 }
 
 // GetLogger forwards to t.Next
-func (t *WorkflowOutboundCallsInterceptorBase) GetLogger(ctx Context) log.Logger {
+func (t *WorkflowOutboundCallsInterceptorBase) GetLogger(ctx Context) tlog.Logger {
 	return t.Next.GetLogger(ctx)
 }
 

--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -38,7 +38,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 type (
@@ -128,7 +128,7 @@ type (
 		activityID         string
 		activityType       ActivityType
 		serviceInvoker     ServiceInvoker
-		logger             log.Logger
+		logger             tlog.Logger
 		metricsScope       tally.Scope
 		isLocalActivity    bool
 		heartbeatTimeout   time.Duration

--- a/internal/internal_activity.go
+++ b/internal/internal_activity.go
@@ -38,7 +38,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 
 	"go.temporal.io/sdk/internal/converter"
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 type (
@@ -128,7 +128,7 @@ type (
 		activityID         string
 		activityType       ActivityType
 		serviceInvoker     ServiceInvoker
-		logger             tlog.Logger
+		logger             log.Logger
 		metricsScope       tally.Scope
 		isLocalActivity    bool
 		heartbeatTimeout   time.Duration

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -47,8 +47,8 @@ import (
 	"go.temporal.io/sdk/internal/common"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
-	tlog "go.temporal.io/sdk/log"
+	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/log"
 )
 
 const (
@@ -118,7 +118,7 @@ type (
 		signalHandler   func(name string, input *commonpb.Payloads) // A signal handler to be invoked on a signal event
 		queryHandler    func(queryType string, queryArgs *commonpb.Payloads) (*commonpb.Payloads, error)
 
-		logger                tlog.Logger
+		logger                log.Logger
 		isReplay              bool // flag to indicate if workflow is in replay mode
 		enableLoggingInReplay bool // flag to indicate if workflow should enable logging in replay mode
 
@@ -165,7 +165,7 @@ var (
 func newWorkflowExecutionEventHandler(
 	workflowInfo *WorkflowInfo,
 	completeHandler completionHandler,
-	logger tlog.Logger,
+	logger log.Logger,
 	enableLoggingInReplay bool,
 	scope tally.Scope,
 	registry *registry,
@@ -189,8 +189,8 @@ func newWorkflowExecutionEventHandler(
 		contextPropagators:    contextPropagators,
 		tracer:                tracer,
 	}
-	context.logger = log.NewReplayLogger(
-		log.With(logger,
+	context.logger = ilog.NewReplayLogger(
+		ilog.With(logger,
 			tagWorkflowType, workflowInfo.WorkflowType.Name,
 			tagWorkflowID, workflowInfo.WorkflowExecution.ID,
 			tagRunID, workflowInfo.WorkflowExecution.RunID,
@@ -395,7 +395,7 @@ func (wc *workflowEnvironmentImpl) RegisterQueryHandler(handler func(string, *co
 	wc.queryHandler = handler
 }
 
-func (wc *workflowEnvironmentImpl) GetLogger() tlog.Logger {
+func (wc *workflowEnvironmentImpl) GetLogger() log.Logger {
 	return wc.logger
 }
 

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -48,6 +48,7 @@ import (
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/converter"
 	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 const (
@@ -117,7 +118,7 @@ type (
 		signalHandler   func(name string, input *commonpb.Payloads) // A signal handler to be invoked on a signal event
 		queryHandler    func(queryType string, queryArgs *commonpb.Payloads) (*commonpb.Payloads, error)
 
-		logger                log.Logger
+		logger                tlog.Logger
 		isReplay              bool // flag to indicate if workflow is in replay mode
 		enableLoggingInReplay bool // flag to indicate if workflow should enable logging in replay mode
 
@@ -164,7 +165,7 @@ var (
 func newWorkflowExecutionEventHandler(
 	workflowInfo *WorkflowInfo,
 	completeHandler completionHandler,
-	logger log.Logger,
+	logger tlog.Logger,
 	enableLoggingInReplay bool,
 	scope tally.Scope,
 	registry *registry,
@@ -394,7 +395,7 @@ func (wc *workflowEnvironmentImpl) RegisterQueryHandler(handler func(string, *co
 	wc.queryHandler = handler
 }
 
-func (wc *workflowEnvironmentImpl) GetLogger() log.Logger {
+func (wc *workflowEnvironmentImpl) GetLogger() tlog.Logger {
 	return wc.logger
 }
 

--- a/internal/internal_pressure_points.go
+++ b/internal/internal_pressure_points.go
@@ -32,7 +32,7 @@ import (
 
 	"go.temporal.io/api/workflowservice/v1"
 
-	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 // ** This is for internal stress testing framework **
@@ -56,7 +56,7 @@ type (
 
 	pressurePointMgrImpl struct {
 		config map[string]map[string]string
-		logger log.Logger
+		logger tlog.Logger
 	}
 )
 

--- a/internal/internal_pressure_points.go
+++ b/internal/internal_pressure_points.go
@@ -32,7 +32,7 @@ import (
 
 	"go.temporal.io/api/workflowservice/v1"
 
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 // ** This is for internal stress testing framework **
@@ -56,7 +56,7 @@ type (
 
 	pressurePointMgrImpl struct {
 		config map[string]map[string]string
-		logger tlog.Logger
+		logger log.Logger
 	}
 )
 

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -53,7 +53,7 @@ import (
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/util"
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 const (
@@ -124,7 +124,7 @@ type (
 		namespace              string
 		metricsScope           *metrics.TaggedScope
 		ppMgr                  pressurePointMgr
-		logger                 log.Logger
+		logger                 tlog.Logger
 		identity               string
 		enableLoggingInReplay  bool
 		disableStickyExecution bool
@@ -144,7 +144,7 @@ type (
 		identity           string
 		service            workflowservice.WorkflowServiceClient
 		metricsScope       *metrics.TaggedScope
-		logger             log.Logger
+		logger             tlog.Logger
 		userContext        context.Context
 		registry           *registry
 		activityProvider   activityProvider

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -53,7 +53,7 @@ import (
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/util"
 	"go.temporal.io/sdk/internal/converter"
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 const (
@@ -124,7 +124,7 @@ type (
 		namespace              string
 		metricsScope           *metrics.TaggedScope
 		ppMgr                  pressurePointMgr
-		logger                 tlog.Logger
+		logger                 log.Logger
 		identity               string
 		enableLoggingInReplay  bool
 		disableStickyExecution bool
@@ -144,7 +144,7 @@ type (
 		identity           string
 		service            workflowservice.WorkflowServiceClient
 		metricsScope       *metrics.TaggedScope
-		logger             tlog.Logger
+		logger             log.Logger
 		userContext        context.Context
 		registry           *registry
 		activityProvider   activityProvider

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -49,6 +49,7 @@ import (
 
 	"go.temporal.io/sdk/internal/converter"
 	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 const (
@@ -58,7 +59,7 @@ const (
 type (
 	TaskHandlersTestSuite struct {
 		suite.Suite
-		logger   log.Logger
+		logger   tlog.Logger
 		service  *workflowservicemock.MockWorkflowServiceClient
 		registry *registry
 	}
@@ -1361,7 +1362,7 @@ func (t *TaskHandlersTestSuite) TestHeartBeat_NilResponseWithNamespaceNotActiveE
 }
 
 type testActivityDeadline struct {
-	logger log.Logger
+	logger tlog.Logger
 	d      time.Duration
 }
 

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -48,8 +48,8 @@ import (
 	"go.temporal.io/api/workflowservicemock/v1"
 
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
-	tlog "go.temporal.io/sdk/log"
+	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/log"
 )
 
 const (
@@ -59,7 +59,7 @@ const (
 type (
 	TaskHandlersTestSuite struct {
 		suite.Suite
-		logger   tlog.Logger
+		logger   log.Logger
 		service  *workflowservicemock.MockWorkflowServiceClient
 		registry *registry
 	}
@@ -126,7 +126,7 @@ func (t *TaskHandlersTestSuite) SetupTest() {
 }
 
 func (t *TaskHandlersTestSuite) SetupSuite() {
-	t.logger = log.NewDefaultLogger()
+	t.logger = ilog.NewDefaultLogger()
 	registerWorkflows(t.registry)
 }
 
@@ -665,7 +665,7 @@ func (t *TaskHandlersTestSuite) TestCacheEvictionWhenErrorOccurs() {
 		Namespace:           testNamespace,
 		TaskQueue:           taskQueue,
 		Identity:            "test-id-1",
-		Logger:              log.NewNopLogger(),
+		Logger:              ilog.NewNopLogger(),
 		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
@@ -700,7 +700,7 @@ func (t *TaskHandlersTestSuite) TestWithMissingHistoryEvents() {
 		Namespace:           testNamespace,
 		TaskQueue:           taskQueue,
 		Identity:            "test-id-1",
-		Logger:              log.NewNopLogger(),
+		Logger:              ilog.NewNopLogger(),
 		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
@@ -741,7 +741,7 @@ func (t *TaskHandlersTestSuite) TestWithTruncatedHistory() {
 		Namespace:           testNamespace,
 		TaskQueue:           taskQueue,
 		Identity:            "test-id-1",
-		Logger:              log.NewNopLogger(),
+		Logger:              ilog.NewNopLogger(),
 		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
@@ -820,7 +820,7 @@ func (t *TaskHandlersTestSuite) testSideEffectDeferHelper(disableSticky bool) {
 		Namespace:              testNamespace,
 		TaskQueue:              taskQueue,
 		Identity:               "test-id-1",
-		Logger:                 log.NewNopLogger(),
+		Logger:                 ilog.NewNopLogger(),
 		DisableStickyExecution: disableSticky,
 	}
 
@@ -863,7 +863,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 		Namespace:           testNamespace,
 		TaskQueue:           taskQueue,
 		Identity:            "test-id-1",
-		Logger:              log.NewNopLogger(),
+		Logger:              ilog.NewNopLogger(),
 		WorkflowPanicPolicy: BlockWorkflow,
 		WorkerStopChannel:   stopC,
 	}
@@ -926,7 +926,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowReturnsPanicError() {
 		Namespace:           testNamespace,
 		TaskQueue:           taskQueue,
 		Identity:            "test-id-1",
-		Logger:              log.NewNopLogger(),
+		Logger:              ilog.NewNopLogger(),
 		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
@@ -953,7 +953,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowPanics() {
 		Namespace:           testNamespace,
 		TaskQueue:           taskQueue,
 		Identity:            "test-id-1",
-		Logger:              log.NewNopLogger(),
+		Logger:              ilog.NewNopLogger(),
 		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
@@ -1008,7 +1008,7 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 		Namespace:           testNamespace,
 		TaskQueue:           taskQueue,
 		Identity:            "test-id-1",
-		Logger:              log.NewNopLogger(),
+		Logger:              ilog.NewNopLogger(),
 		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
@@ -1042,7 +1042,7 @@ func (t *TaskHandlersTestSuite) TestConsistentQuery_InvalidQueryTask() {
 		Namespace:           testNamespace,
 		TaskQueue:           taskQueue,
 		Identity:            "test-id-1",
-		Logger:              log.NewNopLogger(),
+		Logger:              ilog.NewNopLogger(),
 		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
@@ -1362,7 +1362,7 @@ func (t *TaskHandlersTestSuite) TestHeartBeat_NilResponseWithNamespaceNotActiveE
 }
 
 type testActivityDeadline struct {
-	logger tlog.Logger
+	logger log.Logger
 	d      time.Duration
 }
 

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -48,7 +48,7 @@ import (
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/serializer"
 	"go.temporal.io/sdk/internal/converter"
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 const (
@@ -82,7 +82,7 @@ type (
 		service       workflowservice.WorkflowServiceClient
 		taskHandler   WorkflowTaskHandler
 		metricsScope  tally.Scope
-		logger        tlog.Logger
+		logger        log.Logger
 		dataConverter converter.DataConverter
 
 		stickyUUID                   string
@@ -104,7 +104,7 @@ type (
 		service             workflowservice.WorkflowServiceClient
 		taskHandler         ActivityTaskHandler
 		metricsScope        *metrics.TaggedScope
-		logger              tlog.Logger
+		logger              log.Logger
 		activitiesPerSecond float64
 	}
 
@@ -122,14 +122,14 @@ type (
 		basePoller
 		handler      *localActivityTaskHandler
 		metricsScope tally.Scope
-		logger       tlog.Logger
+		logger       log.Logger
 		laTunnel     *localActivityTunnel
 	}
 
 	localActivityTaskHandler struct {
 		userContext        context.Context
 		metricsScope       *metrics.TaggedScope
-		logger             tlog.Logger
+		logger             log.Logger
 		dataConverter      converter.DataConverter
 		contextPropagators []ContextPropagator
 		tracer             opentracing.Tracer

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -48,7 +48,7 @@ import (
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/serializer"
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 const (
@@ -82,7 +82,7 @@ type (
 		service       workflowservice.WorkflowServiceClient
 		taskHandler   WorkflowTaskHandler
 		metricsScope  tally.Scope
-		logger        log.Logger
+		logger        tlog.Logger
 		dataConverter converter.DataConverter
 
 		stickyUUID                   string
@@ -104,7 +104,7 @@ type (
 		service             workflowservice.WorkflowServiceClient
 		taskHandler         ActivityTaskHandler
 		metricsScope        *metrics.TaggedScope
-		logger              log.Logger
+		logger              tlog.Logger
 		activitiesPerSecond float64
 	}
 
@@ -122,14 +122,14 @@ type (
 		basePoller
 		handler      *localActivityTaskHandler
 		metricsScope tally.Scope
-		logger       log.Logger
+		logger       tlog.Logger
 		laTunnel     *localActivityTunnel
 	}
 
 	localActivityTaskHandler struct {
 		userContext        context.Context
 		metricsScope       *metrics.TaggedScope
-		logger             log.Logger
+		logger             tlog.Logger
 		dataConverter      converter.DataConverter
 		contextPropagators []ContextPropagator
 		tracer             opentracing.Tracer

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -61,6 +61,7 @@ import (
 	"go.temporal.io/sdk/internal/common/util"
 	"go.temporal.io/sdk/internal/converter"
 	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 const (
@@ -166,7 +167,7 @@ type (
 
 		MetricsScope tally.Scope
 
-		Logger log.Logger
+		Logger tlog.Logger
 
 		// Enable logging in replay mode
 		EnableLoggingInReplay bool
@@ -232,7 +233,7 @@ func ensureRequiredParams(params *workerExecutionParameters) {
 // verifyNamespaceExist does a DescribeNamespace operation on the specified namespace with backoff/retry
 // It returns an error, if the server returns an EntityNotExist or BadRequest error
 // On any other transient error, this method will just return success
-func verifyNamespaceExist(client workflowservice.WorkflowServiceClient, namespace string, logger log.Logger) error {
+func verifyNamespaceExist(client workflowservice.WorkflowServiceClient, namespace string, logger tlog.Logger) error {
 	ctx := context.Background()
 	descNamespaceOp := func() error {
 		tchCtx, cancel := newChannelContext(ctx)
@@ -843,7 +844,7 @@ type AggregatedWorker struct {
 	workflowWorker *workflowWorker
 	activityWorker *activityWorker
 	sessionWorker  *sessionWorker
-	logger         log.Logger
+	logger         tlog.Logger
 	registry       *registry
 	stopC          chan struct{}
 }
@@ -1039,7 +1040,7 @@ func (aw *WorkflowReplayer) RegisterWorkflowWithOptions(w interface{}, options R
 // ReplayWorkflowHistory executes a single workflow task for the given history.
 // Use for testing the backwards compatibility of code changes and troubleshooting workflows in a debugger.
 // The logger is an optional parameter. Defaults to the noop logger.
-func (aw *WorkflowReplayer) ReplayWorkflowHistory(logger log.Logger, history *historypb.History) error {
+func (aw *WorkflowReplayer) ReplayWorkflowHistory(logger tlog.Logger, history *historypb.History) error {
 	if logger == nil {
 		logger = log.NewDefaultLogger()
 	}
@@ -1053,7 +1054,7 @@ func (aw *WorkflowReplayer) ReplayWorkflowHistory(logger log.Logger, history *hi
 // ReplayWorkflowHistoryFromJSONFile executes a single workflow task for the given json history file.
 // Use for testing the backwards compatibility of code changes and troubleshooting workflows in a debugger.
 // The logger is an optional parameter. Defaults to the noop logger.
-func (aw *WorkflowReplayer) ReplayWorkflowHistoryFromJSONFile(logger log.Logger, jsonfileName string) error {
+func (aw *WorkflowReplayer) ReplayWorkflowHistoryFromJSONFile(logger tlog.Logger, jsonfileName string) error {
 	return aw.ReplayPartialWorkflowHistoryFromJSONFile(logger, jsonfileName, 0)
 }
 
@@ -1061,7 +1062,7 @@ func (aw *WorkflowReplayer) ReplayWorkflowHistoryFromJSONFile(logger log.Logger,
 // lastEventID(inclusive).
 // Use for testing the backwards compatibility of code changes and troubleshooting workflows in a debugger.
 // The logger is an optional parameter. Defaults to the noop logger.
-func (aw *WorkflowReplayer) ReplayPartialWorkflowHistoryFromJSONFile(loger log.Logger, jsonfileName string, lastEventID int64) error {
+func (aw *WorkflowReplayer) ReplayPartialWorkflowHistoryFromJSONFile(loger tlog.Logger, jsonfileName string, lastEventID int64) error {
 	history, err := extractHistoryFromFile(jsonfileName, lastEventID)
 
 	if err != nil {
@@ -1079,7 +1080,7 @@ func (aw *WorkflowReplayer) ReplayPartialWorkflowHistoryFromJSONFile(loger log.L
 }
 
 // ReplayWorkflowExecution replays workflow execution loading it from Temporal service.
-func (aw *WorkflowReplayer) ReplayWorkflowExecution(ctx context.Context, service workflowservice.WorkflowServiceClient, logger log.Logger, namespace string, execution WorkflowExecution) error {
+func (aw *WorkflowReplayer) ReplayWorkflowExecution(ctx context.Context, service workflowservice.WorkflowServiceClient, logger tlog.Logger, namespace string, execution WorkflowExecution) error {
 	if logger == nil {
 		logger = log.NewDefaultLogger()
 	}
@@ -1109,7 +1110,7 @@ func (aw *WorkflowReplayer) ReplayWorkflowExecution(ctx context.Context, service
 	return aw.replayWorkflowHistory(logger, service, namespace, hResponse.History)
 }
 
-func (aw *WorkflowReplayer) replayWorkflowHistory(loger log.Logger, service workflowservice.WorkflowServiceClient, namespace string, history *historypb.History) error {
+func (aw *WorkflowReplayer) replayWorkflowHistory(loger tlog.Logger, service workflowservice.WorkflowServiceClient, namespace string, history *historypb.History) error {
 	taskQueue := "ReplayTaskQueue"
 	events := history.Events
 	if events == nil {

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -43,6 +43,7 @@ import (
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/converter"
 	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 const (
@@ -84,7 +85,7 @@ type (
 		RequestCancelChildWorkflow(namespace, workflowID string)
 		RequestCancelExternalWorkflow(namespace, workflowID, runID string, callback ResultHandler)
 		ExecuteChildWorkflow(params ExecuteWorkflowParams, callback ResultHandler, startedHandler func(r WorkflowExecution, e error))
-		GetLogger() log.Logger
+		GetLogger() tlog.Logger
 		GetMetricsScope() tally.Scope
 		// Must be called before WorkflowDefinition.Execute returns
 		RegisterSignalHandler(handler func(name string, input *commonpb.Payloads))
@@ -145,7 +146,7 @@ type (
 		limiterContext       context.Context
 		limiterContextCancel func()
 		retrier              *backoff.ConcurrentRetrier // Service errors back off retrier
-		logger               log.Logger
+		logger               tlog.Logger
 		metricsScope         tally.Scope
 
 		pollerRequestCh    chan struct{}
@@ -170,7 +171,7 @@ func createPollRetryPolicy() backoff.RetryPolicy {
 	return policy
 }
 
-func newBaseWorker(options baseWorkerOptions, logger log.Logger, metricsScope tally.Scope, sessionTokenBucket *sessionTokenBucket) *baseWorker {
+func newBaseWorker(options baseWorkerOptions, logger tlog.Logger, metricsScope tally.Scope, sessionTokenBucket *sessionTokenBucket) *baseWorker {
 	ctx, cancel := context.WithCancel(context.Background())
 	bw := &baseWorker{
 		options:         options,

--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -40,7 +40,7 @@ import (
 	"go.temporal.io/api/workflowservicemock/v1"
 
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	ilog "go.temporal.io/sdk/internal/log"
 )
 
 const (
@@ -185,7 +185,7 @@ func (s *InterfacesTestSuite) TestInterface() {
 		TaskQueue:                             "testTaskQueue",
 		MaxConcurrentActivityTaskQueuePollers: 4,
 		MaxConcurrentWorkflowTaskQueuePollers: 4,
-		Logger:                                log.NewDefaultLogger(),
+		Logger:                                ilog.NewDefaultLogger(),
 		Tracer:                                opentracing.NoopTracer{},
 	}
 
@@ -216,7 +216,7 @@ func (s *InterfacesTestSuite) TestInterface() {
 		TaskQueue:                             "testTaskQueue",
 		MaxConcurrentActivityTaskQueuePollers: 10,
 		MaxConcurrentWorkflowTaskQueuePollers: 10,
-		Logger:                                log.NewDefaultLogger(),
+		Logger:                                ilog.NewDefaultLogger(),
 		Tracer:                                opentracing.NoopTracer{},
 	}
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -52,6 +52,7 @@ import (
 
 	"go.temporal.io/sdk/internal/converter"
 	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 func testInternalWorkerRegister(r *registry) {
@@ -162,7 +163,7 @@ func (s *internalWorkerTestSuite) createLocalActivityMarkerDataForTest(activityI
 	}
 }
 
-func getLogger() log.Logger {
+func getLogger() tlog.Logger {
 	return log.NewDefaultLogger()
 }
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -51,8 +51,8 @@ import (
 	"google.golang.org/grpc"
 
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
-	tlog "go.temporal.io/sdk/log"
+	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/log"
 )
 
 func testInternalWorkerRegister(r *registry) {
@@ -163,8 +163,8 @@ func (s *internalWorkerTestSuite) createLocalActivityMarkerDataForTest(activityI
 	}
 }
 
-func getLogger() tlog.Logger {
-	return log.NewDefaultLogger()
+func getLogger() log.Logger {
+	return ilog.NewDefaultLogger()
 }
 
 func testReplayWorkflow(ctx Context) error {
@@ -1780,7 +1780,7 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 		dataConverter:      &converter.CompositeDataConverter{},
 		contextPropagators: nil,
 		tracer:             nil,
-		logger:             log.NewNopLogger(),
+		logger:             ilog.NewNopLogger(),
 	}
 
 	options := WorkerOptions{

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -42,7 +42,7 @@ import (
 	"google.golang.org/grpc"
 
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	ilog "go.temporal.io/sdk/internal/log"
 )
 
 // ActivityTaskHandler never returns response
@@ -100,7 +100,7 @@ func (s *WorkersTestSuite) TestWorkflowWorker() {
 		Namespace:                             DefaultNamespace,
 		TaskQueue:                             "testTaskQueue",
 		MaxConcurrentWorkflowTaskQueuePollers: 5,
-		Logger:                                log.NewDefaultLogger(),
+		Logger:                                ilog.NewDefaultLogger(),
 		UserContext:                           ctx,
 		UserContextCancel:                     cancel,
 	}
@@ -121,7 +121,7 @@ func (s *WorkersTestSuite) TestActivityWorker() {
 		Namespace:                             DefaultNamespace,
 		TaskQueue:                             "testTaskQueue",
 		MaxConcurrentActivityTaskQueuePollers: 5,
-		Logger:                                log.NewDefaultLogger(),
+		Logger:                                ilog.NewDefaultLogger(),
 	}
 	overrides := &workerOverrides{activityTaskHandler: newSampleActivityTaskHandler()}
 	a := &greeterActivity{}
@@ -162,7 +162,7 @@ func (s *WorkersTestSuite) TestActivityWorkerStop() {
 		TaskQueue:                             "testTaskQueue",
 		MaxConcurrentActivityTaskQueuePollers: 5,
 		ConcurrentActivityExecutionSize:       2,
-		Logger:                                log.NewDefaultLogger(),
+		Logger:                                ilog.NewDefaultLogger(),
 		UserContext:                           ctx,
 		UserContextCancel:                     cancel,
 		WorkerStopTimeout:                     time.Second * 2,
@@ -195,7 +195,7 @@ func (s *WorkersTestSuite) TestPollWorkflowTaskQueue_InternalServiceError() {
 		Namespace:                             DefaultNamespace,
 		TaskQueue:                             "testWorkflowTaskQueue",
 		MaxConcurrentWorkflowTaskQueuePollers: 5,
-		Logger:                                log.NewNopLogger(),
+		Logger:                                ilog.NewNopLogger(),
 	}
 	overrides := &workerOverrides{workflowTaskHandler: newSampleWorkflowTaskHandler()}
 	workflowWorker := newWorkflowWorkerInternal(s.service, executionParameters, nil, overrides, newRegistry())

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -48,7 +48,7 @@ import (
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/serializer"
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 // Assert that structs do indeed implement the interfaces
@@ -70,7 +70,7 @@ type (
 		connectionCloser   io.Closer
 		namespace          string
 		registry           *registry
-		logger             log.Logger
+		logger             tlog.Logger
 		metricsScope       *metrics.TaggedScope
 		identity           string
 		dataConverter      converter.DataConverter
@@ -83,7 +83,7 @@ type (
 		workflowService  workflowservice.WorkflowServiceClient
 		connectionCloser io.Closer
 		metricsScope     tally.Scope
-		logger           log.Logger
+		logger           tlog.Logger
 		identity         string
 	}
 

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -48,7 +48,7 @@ import (
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/serializer"
 	"go.temporal.io/sdk/internal/converter"
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 // Assert that structs do indeed implement the interfaces
@@ -70,7 +70,7 @@ type (
 		connectionCloser   io.Closer
 		namespace          string
 		registry           *registry
-		logger             tlog.Logger
+		logger             log.Logger
 		metricsScope       *metrics.TaggedScope
 		identity           string
 		dataConverter      converter.DataConverter
@@ -83,7 +83,7 @@ type (
 		workflowService  workflowservice.WorkflowServiceClient
 		connectionCloser io.Closer
 		metricsScope     tally.Scope
-		logger           tlog.Logger
+		logger           log.Logger
 		identity         string
 	}
 

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -38,7 +38,7 @@ import (
 
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	ilog "go.temporal.io/sdk/internal/log"
 )
 
 type WorkflowUnitTest struct {
@@ -202,7 +202,7 @@ func (s *WorkflowUnitTest) Test_SplitJoinActivityWorkflow() {
 
 func TestWorkflowPanic(t *testing.T) {
 	ts := &WorkflowTestSuite{}
-	ts.SetLogger(log.NewNopLogger()) // this test simulate panic, use nop logger to avoid logging noise
+	ts.SetLogger(ilog.NewNopLogger()) // this test simulate panic, use nop logger to avoid logging noise
 	env := ts.NewTestWorkflowEnvironment()
 	env.RegisterActivity(testAct)
 	env.ExecuteWorkflow(splitJoinActivityWorkflow, true)
@@ -222,7 +222,7 @@ func TestWorkflowPanic(t *testing.T) {
 
 func TestWorkflowReturnsPanic(t *testing.T) {
 	ts := &WorkflowTestSuite{}
-	ts.SetLogger(log.NewNopLogger()) // this test simulate panic, use nop logger to avoid logging noise
+	ts.SetLogger(ilog.NewNopLogger()) // this test simulate panic, use nop logger to avoid logging noise
 	env := ts.NewTestWorkflowEnvironment()
 	env.ExecuteWorkflow(returnPanicWorkflow)
 	require.True(t, env.IsWorkflowCompleted())

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -51,8 +51,8 @@ import (
 	"go.temporal.io/sdk/internal/common"
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
-	tlog "go.temporal.io/sdk/log"
+	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/log"
 )
 
 const (
@@ -134,7 +134,7 @@ type (
 
 		mock               *mock.Mock
 		service            workflowservice.WorkflowServiceClient
-		logger             tlog.Logger
+		logger             log.Logger
 		metricsScope       *metrics.TaggedScope
 		contextPropagators []ContextPropagator
 		identity           string
@@ -266,7 +266,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 	env.runningWorkflows[env.workflowInfo.WorkflowExecution.ID] = &testWorkflowHandle{env: env, callback: func(result *commonpb.Payloads, err error) {}}
 
 	if env.logger == nil {
-		env.logger = log.NewDefaultLogger()
+		env.logger = ilog.NewDefaultLogger()
 	}
 	if env.metricsScope == nil {
 		env.metricsScope = metrics.NewTaggedScope(s.scope)
@@ -275,7 +275,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 	env.header = s.header
 
 	// setup mock service
-	mockCtrl := gomock.NewController(log.NewTestReporter(env.logger))
+	mockCtrl := gomock.NewController(ilog.NewTestReporter(env.logger))
 	mockService := workflowservicemock.NewMockWorkflowServiceClient(mockCtrl)
 
 	mockHeartbeatFn := func(c context.Context, r *workflowservice.RecordActivityTaskHeartbeatRequest, opts ...grpc.CallOption) error {
@@ -964,7 +964,7 @@ func (env *testWorkflowEnvironmentImpl) CompleteActivity(taskToken []byte, resul
 	return nil
 }
 
-func (env *testWorkflowEnvironmentImpl) GetLogger() tlog.Logger {
+func (env *testWorkflowEnvironmentImpl) GetLogger() log.Logger {
 	return env.logger
 }
 

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -52,6 +52,7 @@ import (
 	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/converter"
 	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 const (
@@ -133,7 +134,7 @@ type (
 
 		mock               *mock.Mock
 		service            workflowservice.WorkflowServiceClient
-		logger             log.Logger
+		logger             tlog.Logger
 		metricsScope       *metrics.TaggedScope
 		contextPropagators []ContextPropagator
 		identity           string
@@ -963,7 +964,7 @@ func (env *testWorkflowEnvironmentImpl) CompleteActivity(taskToken []byte, resul
 	return nil
 }
 
-func (env *testWorkflowEnvironmentImpl) GetLogger() log.Logger {
+func (env *testWorkflowEnvironmentImpl) GetLogger() tlog.Logger {
 	return env.logger
 }
 

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -41,7 +41,7 @@ import (
 	"go.uber.org/atomic"
 
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	ilog "go.temporal.io/sdk/internal/log"
 )
 
 type WorkflowTestSuiteUnitTest struct {
@@ -1134,7 +1134,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_MockWorkflowWait() {
 func (s *WorkflowTestSuiteUnitTest) Test_MockPanic() {
 	// mock panic, verify that the panic won't be swallowed by our panic handler to detect unexpected mock call.
 	oldLogger := s.GetLogger()
-	s.SetLogger(log.NewNopLogger()) // use no-op logger to avoid noisy logging by panic
+	s.SetLogger(ilog.NewNopLogger()) // use no-op logger to avoid noisy logging by panic
 	env := s.NewTestWorkflowEnvironment()
 	env.OnActivity(testActivityHello, mock.Anything, mock.Anything).
 		Return("hello_mock_panic", nil).

--- a/internal/log/default_logger.go
+++ b/internal/log/default_logger.go
@@ -29,6 +29,8 @@ import (
 	"log"
 	"os"
 	"strings"
+
+	tlog "go.temporal.io/sdk/log"
 )
 
 // DefaultLogger is Logger implementation on top of standart log.Logger. It is used if logger is not specified.
@@ -72,7 +74,7 @@ func (l *DefaultLogger) Error(msg string, keyvals ...interface{}) {
 }
 
 // With returns new logger the prepend every log entry with keyvals.
-func (l *DefaultLogger) With(keyvals ...interface{}) Logger {
+func (l *DefaultLogger) With(keyvals ...interface{}) tlog.Logger {
 	logger := &DefaultLogger{
 		logger: l.logger,
 	}

--- a/internal/log/default_logger.go
+++ b/internal/log/default_logger.go
@@ -26,22 +26,22 @@ package log
 
 import (
 	"fmt"
-	"log"
+	golog "log"
 	"os"
 	"strings"
 
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 // DefaultLogger is Logger implementation on top of standart log.Logger. It is used if logger is not specified.
 type DefaultLogger struct {
-	logger        *log.Logger
+	logger        *golog.Logger
 	globalKeyvals string
 }
 
 // NewDefaultLogger creates new instance of DefaultLogger.
 func NewDefaultLogger() *DefaultLogger {
-	return &DefaultLogger{logger: log.New(os.Stdout, "", log.LstdFlags)}
+	return &DefaultLogger{logger: golog.New(os.Stdout, "", golog.LstdFlags)}
 }
 
 func (l *DefaultLogger) println(level, msg string, keyvals []interface{}) {
@@ -74,7 +74,7 @@ func (l *DefaultLogger) Error(msg string, keyvals ...interface{}) {
 }
 
 // With returns new logger the prepend every log entry with keyvals.
-func (l *DefaultLogger) With(keyvals ...interface{}) tlog.Logger {
+func (l *DefaultLogger) With(keyvals ...interface{}) log.Logger {
 	logger := &DefaultLogger{
 		logger: l.logger,
 	}

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -28,11 +28,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"go.temporal.io/sdk/log"
 )
 
 func TestMemoryLogger_With(t *testing.T) {
 	logger := NewMemoryLogger()
-	withLogger := With(logger, "p1", 1, "p2", "v2")
+	withLogger := log.With(logger, "p1", 1, "p2", "v2")
 	withLogger.Info("message", "p3", float64(3))
 	logger.Info("message2", "p4", 4)
 
@@ -42,7 +44,7 @@ func TestMemoryLogger_With(t *testing.T) {
 
 func TestWithLogger(t *testing.T) {
 	logger := NewMemoryLogger()
-	withLogger := newWithLogger(logger, "p1", 1, "p2", "v2")
+	withLogger := log.newWithLogger(logger, "p1", 1, "p2", "v2")
 	withLogger.Info("message", "p3", float64(3))
 	logger.Info("message2", "p4", 4)
 

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -28,13 +28,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"go.temporal.io/sdk/log"
 )
 
 func TestMemoryLogger_With(t *testing.T) {
 	logger := NewMemoryLogger()
-	withLogger := log.With(logger, "p1", 1, "p2", "v2")
+	withLogger := With(logger, "p1", 1, "p2", "v2")
 	withLogger.Info("message", "p3", float64(3))
 	logger.Info("message2", "p4", 4)
 
@@ -44,7 +42,7 @@ func TestMemoryLogger_With(t *testing.T) {
 
 func TestWithLogger(t *testing.T) {
 	logger := NewMemoryLogger()
-	withLogger := log.newWithLogger(logger, "p1", 1, "p2", "v2")
+	withLogger := newWithLogger(logger, "p1", 1, "p2", "v2")
 	withLogger.Info("message", "p3", float64(3))
 	logger.Info("message2", "p4", 4)
 

--- a/internal/log/memory_logger.go
+++ b/internal/log/memory_logger.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"strings"
 
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 // MemoryLogger is Logger implementation that stores logs in memory (useful for testing). Use Lines() to get log lines.
@@ -75,7 +75,7 @@ func (l *MemoryLogger) Error(msg string, keyvals ...interface{}) {
 }
 
 // With returns new logger the prepend every log entry with keyvals.
-func (l *MemoryLogger) With(keyvals ...interface{}) tlog.Logger {
+func (l *MemoryLogger) With(keyvals ...interface{}) log.Logger {
 	logger := &MemoryLogger{
 		lines: l.lines,
 	}

--- a/internal/log/memory_logger.go
+++ b/internal/log/memory_logger.go
@@ -27,6 +27,8 @@ package log
 import (
 	"fmt"
 	"strings"
+
+	tlog "go.temporal.io/sdk/log"
 )
 
 // MemoryLogger is Logger implementation that stores logs in memory (useful for testing). Use Lines() to get log lines.
@@ -73,7 +75,7 @@ func (l *MemoryLogger) Error(msg string, keyvals ...interface{}) {
 }
 
 // With returns new logger the prepend every log entry with keyvals.
-func (l *MemoryLogger) With(keyvals ...interface{}) Logger {
+func (l *MemoryLogger) With(keyvals ...interface{}) tlog.Logger {
 	logger := &MemoryLogger{
 		lines: l.lines,
 	}

--- a/internal/log/nop_logger.go
+++ b/internal/log/nop_logger.go
@@ -24,6 +24,10 @@
 
 package log
 
+import (
+	tlog "go.temporal.io/sdk/log"
+)
+
 // NopLogger is Logger implementation that doesn't produce any logs.
 type NopLogger struct {
 }
@@ -50,6 +54,6 @@ func (l *NopLogger) Error(msg string, keyvals ...interface{}) {
 }
 
 // With returns new NopLogger.
-func (l *NopLogger) With(keyvals ...interface{}) Logger {
+func (l *NopLogger) With(keyvals ...interface{}) tlog.Logger {
 	return NewNopLogger()
 }

--- a/internal/log/nop_logger.go
+++ b/internal/log/nop_logger.go
@@ -25,7 +25,7 @@
 package log
 
 import (
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 // NopLogger is Logger implementation that doesn't produce any logs.
@@ -54,6 +54,6 @@ func (l *NopLogger) Error(msg string, keyvals ...interface{}) {
 }
 
 // With returns new NopLogger.
-func (l *NopLogger) With(keyvals ...interface{}) tlog.Logger {
+func (l *NopLogger) With(keyvals ...interface{}) log.Logger {
 	return NewNopLogger()
 }

--- a/internal/log/replay_logger.go
+++ b/internal/log/replay_logger.go
@@ -24,15 +24,19 @@
 
 package log
 
+import (
+	tlog "go.temporal.io/sdk/log"
+)
+
 // ReplayLogger is Logger implementation that is aware of replay.
 type ReplayLogger struct {
-	logger                Logger
+	logger                tlog.Logger
 	isReplay              *bool // pointer to bool that indicate if it is in replay mode
 	enableLoggingInReplay *bool // pointer to bool that indicate if logging is enabled in replay mode
 }
 
 // NewReplayLogger crates new instance of ReplayLogger.
-func NewReplayLogger(logger Logger, isReplay *bool, enableLoggingInReplay *bool) Logger {
+func NewReplayLogger(logger tlog.Logger, isReplay *bool, enableLoggingInReplay *bool) tlog.Logger {
 	return &ReplayLogger{
 		logger:                logger,
 		isReplay:              isReplay,
@@ -73,6 +77,6 @@ func (l *ReplayLogger) Error(msg string, keyvals ...interface{}) {
 }
 
 // With returns new logger the prepend every log entry with keyvals.
-func (l *ReplayLogger) With(keyvals ...interface{}) Logger {
+func (l *ReplayLogger) With(keyvals ...interface{}) tlog.Logger {
 	return NewReplayLogger(With(l.logger, keyvals), l.isReplay, l.enableLoggingInReplay)
 }

--- a/internal/log/replay_logger.go
+++ b/internal/log/replay_logger.go
@@ -25,18 +25,18 @@
 package log
 
 import (
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 // ReplayLogger is Logger implementation that is aware of replay.
 type ReplayLogger struct {
-	logger                tlog.Logger
+	logger                log.Logger
 	isReplay              *bool // pointer to bool that indicate if it is in replay mode
 	enableLoggingInReplay *bool // pointer to bool that indicate if logging is enabled in replay mode
 }
 
 // NewReplayLogger crates new instance of ReplayLogger.
-func NewReplayLogger(logger tlog.Logger, isReplay *bool, enableLoggingInReplay *bool) tlog.Logger {
+func NewReplayLogger(logger log.Logger, isReplay *bool, enableLoggingInReplay *bool) log.Logger {
 	return &ReplayLogger{
 		logger:                logger,
 		isReplay:              isReplay,
@@ -77,6 +77,6 @@ func (l *ReplayLogger) Error(msg string, keyvals ...interface{}) {
 }
 
 // With returns new logger the prepend every log entry with keyvals.
-func (l *ReplayLogger) With(keyvals ...interface{}) tlog.Logger {
+func (l *ReplayLogger) With(keyvals ...interface{}) log.Logger {
 	return NewReplayLogger(With(l.logger, keyvals), l.isReplay, l.enableLoggingInReplay)
 }

--- a/internal/log/test_reporter.go
+++ b/internal/log/test_reporter.go
@@ -27,15 +27,17 @@ package log
 import (
 	"fmt"
 	"os"
+
+	tlog "go.temporal.io/sdk/log"
 )
 
 // TestReporter is a log adapter for gomock.
 type TestReporter struct {
-	logger Logger
+	logger tlog.Logger
 }
 
 // NewTestReporter creates new instance of TestReporter.
-func NewTestReporter(logger Logger) *TestReporter {
+func NewTestReporter(logger tlog.Logger) *TestReporter {
 	return &TestReporter{logger: logger}
 }
 

--- a/internal/log/test_reporter.go
+++ b/internal/log/test_reporter.go
@@ -28,16 +28,16 @@ import (
 	"fmt"
 	"os"
 
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 // TestReporter is a log adapter for gomock.
 type TestReporter struct {
-	logger tlog.Logger
+	logger log.Logger
 }
 
 // NewTestReporter creates new instance of TestReporter.
-func NewTestReporter(logger tlog.Logger) *TestReporter {
+func NewTestReporter(logger log.Logger) *TestReporter {
 	return &TestReporter{logger: logger}
 }
 

--- a/internal/log/with_logger.go
+++ b/internal/log/with_logger.go
@@ -25,12 +25,12 @@
 package log
 
 import (
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 // With returns Logger instance that prepend every log entry with keyvals. If logger implments WithLogger it is used, otherwise every log call will be intercepted.
-func With(logger tlog.Logger, keyvals ...interface{}) tlog.Logger {
-	if wl, ok := logger.(tlog.WithLogger); ok {
+func With(logger log.Logger, keyvals ...interface{}) log.Logger {
+	if wl, ok := logger.(log.WithLogger); ok {
 		return wl.With(keyvals...)
 	}
 
@@ -38,11 +38,11 @@ func With(logger tlog.Logger, keyvals ...interface{}) tlog.Logger {
 }
 
 type withLogger struct {
-	logger  tlog.Logger
+	logger  log.Logger
 	keyvals []interface{}
 }
 
-func newWithLogger(logger tlog.Logger, keyvals ...interface{}) *withLogger {
+func newWithLogger(logger log.Logger, keyvals ...interface{}) *withLogger {
 	return &withLogger{logger: logger, keyvals: keyvals}
 }
 

--- a/internal/log/with_logger.go
+++ b/internal/log/with_logger.go
@@ -24,14 +24,13 @@
 
 package log
 
-// WithLogger is an interface that prepend every log entry with keyvals.
-type WithLogger interface {
-	With(keyvals ...interface{}) Logger
-}
+import (
+	tlog "go.temporal.io/sdk/log"
+)
 
 // With returns Logger instance that prepend every log entry with keyvals. If logger implments WithLogger it is used, otherwise every log call will be intercepted.
-func With(logger Logger, keyvals ...interface{}) Logger {
-	if wl, ok := logger.(WithLogger); ok {
+func With(logger tlog.Logger, keyvals ...interface{}) tlog.Logger {
+	if wl, ok := logger.(tlog.WithLogger); ok {
 		return wl.With(keyvals...)
 	}
 
@@ -39,11 +38,11 @@ func With(logger Logger, keyvals ...interface{}) Logger {
 }
 
 type withLogger struct {
-	logger  Logger
+	logger  tlog.Logger
 	keyvals []interface{}
 }
 
-func newWithLogger(logger Logger, keyvals ...interface{}) *withLogger {
+func newWithLogger(logger tlog.Logger, keyvals ...interface{}) *withLogger {
 	return &withLogger{logger: logger, keyvals: keyvals}
 }
 

--- a/internal/tracer.go
+++ b/internal/tracer.go
@@ -31,7 +31,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 
 	"go.temporal.io/sdk/internal/converter"
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 type tracingReader struct {
@@ -77,12 +77,12 @@ func (t tracingWriter) Set(key, val string) {
 //		the header and puts it in the Context object. Does not start a new span
 //		as that is started outside when the workflow is actually executed
 type tracingContextPropagator struct {
-	logger tlog.Logger
+	logger log.Logger
 	tracer opentracing.Tracer
 }
 
 // NewTracingContextPropagator returns new tracing context propagator object
-func NewTracingContextPropagator(logger tlog.Logger, tracer opentracing.Tracer) ContextPropagator {
+func NewTracingContextPropagator(logger log.Logger, tracer opentracing.Tracer) ContextPropagator {
 	return &tracingContextPropagator{logger, tracer}
 }
 

--- a/internal/tracer.go
+++ b/internal/tracer.go
@@ -31,7 +31,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 type tracingReader struct {
@@ -77,12 +77,12 @@ func (t tracingWriter) Set(key, val string) {
 //		the header and puts it in the Context object. Does not start a new span
 //		as that is started outside when the workflow is actually executed
 type tracingContextPropagator struct {
-	logger log.Logger
+	logger tlog.Logger
 	tracer opentracing.Tracer
 }
 
 // NewTracingContextPropagator returns new tracing context propagator object
-func NewTracingContextPropagator(logger log.Logger, tracer opentracing.Tracer) ContextPropagator {
+func NewTracingContextPropagator(logger tlog.Logger, tracer opentracing.Tracer) ContextPropagator {
 	return &tracingContextPropagator{logger, tracer}
 }
 

--- a/internal/tracer_test.go
+++ b/internal/tracer_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/uber/jaeger-client-go/config"
 	commonpb "go.temporal.io/api/common/v1"
 
-	"go.temporal.io/sdk/internal/log"
+	ilog "go.temporal.io/sdk/internal/log"
 )
 
 func TestTracingContextPropagator(t *testing.T) {
@@ -42,7 +42,7 @@ func TestTracingContextPropagator(t *testing.T) {
 	tracer, closer, err := config.Configuration{ServiceName: "test-service"}.NewTracer()
 	require.NoError(t, err)
 	defer func() { _ = closer.Close() }()
-	ctxProp := NewTracingContextPropagator(log.NewNopLogger(), tracer)
+	ctxProp := NewTracingContextPropagator(ilog.NewNopLogger(), tracer)
 
 	span := tracer.StartSpan("test-operation")
 	ctx := context.Background()
@@ -64,7 +64,7 @@ func TestTracingContextPropagator(t *testing.T) {
 
 func TestTracingContextPropagatorNoSpan(t *testing.T) {
 	t.Parallel()
-	ctxProp := NewTracingContextPropagator(log.NewNopLogger(), opentracing.NoopTracer{})
+	ctxProp := NewTracingContextPropagator(ilog.NewNopLogger(), opentracing.NoopTracer{})
 
 	header := &commonpb.Header{
 		Fields: map[string]*commonpb.Payload{},
@@ -82,7 +82,7 @@ func TestTracingContextPropagatorWorkflowContext(t *testing.T) {
 	tracer, closer, err := config.Configuration{ServiceName: "test-service"}.NewTracer()
 	require.NoError(t, err)
 	defer func() { _ = closer.Close() }()
-	ctxProp := NewTracingContextPropagator(log.NewNopLogger(), tracer)
+	ctxProp := NewTracingContextPropagator(ilog.NewNopLogger(), tracer)
 
 	span := tracer.StartSpan("test-operation")
 	assert.NotNil(t, span.Context())
@@ -109,7 +109,7 @@ func TestTracingContextPropagatorWorkflowContext(t *testing.T) {
 
 func TestTracingContextPropagatorWorkflowContextNoSpan(t *testing.T) {
 	t.Parallel()
-	ctxProp := NewTracingContextPropagator(log.NewNopLogger(), opentracing.NoopTracer{})
+	ctxProp := NewTracingContextPropagator(ilog.NewNopLogger(), opentracing.NoopTracer{})
 
 	header := &commonpb.Header{
 		Fields: map[string]*commonpb.Payload{},
@@ -127,7 +127,7 @@ func TestConsistentInjectionExtraction(t *testing.T) {
 	tracer, closer, err := config.Configuration{ServiceName: "test-service"}.NewTracer()
 	require.NoError(t, err)
 	defer func() { _ = closer.Close() }()
-	ctxProp := NewTracingContextPropagator(log.NewNopLogger(), tracer)
+	ctxProp := NewTracingContextPropagator(ilog.NewNopLogger(), tracer)
 
 	span := tracer.StartSpan("test-operation")
 	// base64 encoded string '{}'

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -38,7 +38,7 @@ import (
 	"go.temporal.io/sdk/internal/common"
 	"go.temporal.io/sdk/internal/common/backoff"
 	"go.temporal.io/sdk/internal/converter"
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 var (
@@ -764,12 +764,12 @@ func (wc *workflowEnvironmentInterceptor) GetWorkflowInfo(ctx Context) *Workflow
 }
 
 // GetLogger returns a logger to be used in workflow's context
-func GetLogger(ctx Context) tlog.Logger {
+func GetLogger(ctx Context) log.Logger {
 	i := getWorkflowOutboundCallsInterceptor(ctx)
 	return i.GetLogger(ctx)
 }
 
-func (wc *workflowEnvironmentInterceptor) GetLogger(ctx Context) tlog.Logger {
+func (wc *workflowEnvironmentInterceptor) GetLogger(ctx Context) log.Logger {
 	return wc.env.GetLogger()
 }
 

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -38,7 +38,7 @@ import (
 	"go.temporal.io/sdk/internal/common"
 	"go.temporal.io/sdk/internal/common/backoff"
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 var (
@@ -764,12 +764,12 @@ func (wc *workflowEnvironmentInterceptor) GetWorkflowInfo(ctx Context) *Workflow
 }
 
 // GetLogger returns a logger to be used in workflow's context
-func GetLogger(ctx Context) log.Logger {
+func GetLogger(ctx Context) tlog.Logger {
 	i := getWorkflowOutboundCallsInterceptor(ctx)
 	return i.GetLogger(ctx)
 }
 
-func (wc *workflowEnvironmentInterceptor) GetLogger(ctx Context) log.Logger {
+func (wc *workflowEnvironmentInterceptor) GetLogger(ctx Context) tlog.Logger {
 	return wc.env.GetLogger()
 }
 

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -39,7 +39,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 
 	"go.temporal.io/sdk/internal/converter"
-	"go.temporal.io/sdk/internal/log"
+	tlog "go.temporal.io/sdk/log"
 )
 
 type (
@@ -54,7 +54,7 @@ type (
 
 	// WorkflowTestSuite is the test suite to run unit tests for workflow/activity.
 	WorkflowTestSuite struct {
-		logger             log.Logger
+		logger             tlog.Logger
 		scope              tally.Scope
 		contextPropagators []ContextPropagator
 		header             *commonpb.Header
@@ -134,12 +134,12 @@ func (s *WorkflowTestSuite) NewTestActivityEnvironment() *TestActivityEnvironmen
 
 // SetLogger sets the logger for this WorkflowTestSuite. If you don't set logger, test suite will create a default logger
 // with Debug level logging enabled.
-func (s *WorkflowTestSuite) SetLogger(logger log.Logger) {
+func (s *WorkflowTestSuite) SetLogger(logger tlog.Logger) {
 	s.logger = logger
 }
 
 // GetLogger gets the logger for this WorkflowTestSuite.
-func (s *WorkflowTestSuite) GetLogger() log.Logger {
+func (s *WorkflowTestSuite) GetLogger() tlog.Logger {
 	return s.logger
 }
 

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -39,7 +39,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 
 	"go.temporal.io/sdk/internal/converter"
-	tlog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/log"
 )
 
 type (
@@ -54,7 +54,7 @@ type (
 
 	// WorkflowTestSuite is the test suite to run unit tests for workflow/activity.
 	WorkflowTestSuite struct {
-		logger             tlog.Logger
+		logger             log.Logger
 		scope              tally.Scope
 		contextPropagators []ContextPropagator
 		header             *commonpb.Header
@@ -134,12 +134,12 @@ func (s *WorkflowTestSuite) NewTestActivityEnvironment() *TestActivityEnvironmen
 
 // SetLogger sets the logger for this WorkflowTestSuite. If you don't set logger, test suite will create a default logger
 // with Debug level logging enabled.
-func (s *WorkflowTestSuite) SetLogger(logger tlog.Logger) {
+func (s *WorkflowTestSuite) SetLogger(logger log.Logger) {
 	s.logger = logger
 }
 
 // GetLogger gets the logger for this WorkflowTestSuite.
-func (s *WorkflowTestSuite) GetLogger() tlog.Logger {
+func (s *WorkflowTestSuite) GetLogger() log.Logger {
 	return s.logger
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -22,16 +22,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package client
-
-import (
-	"go.temporal.io/sdk/internal/log"
-)
+package log
 
 type (
 	// Logger is an interface that can be passed to ClientOptions.Logger.
-	Logger = log.Logger
-
-	// WithLogger is an interface that prepend every log entry with keyvals.
-	WithLogger = log.WithLogger
+	Logger interface {
+		Debug(msg string, keyvals ...interface{})
+		Info(msg string, keyvals ...interface{})
+		Warn(msg string, keyvals ...interface{})
+		Error(msg string, keyvals ...interface{})
+	}
 )

--- a/log/with_logger.go
+++ b/log/with_logger.go
@@ -24,10 +24,7 @@
 
 package log
 
-// Logger is an interface that can be passed to ClientOptions.Logger.
-type Logger interface {
-	Debug(msg string, keyvals ...interface{})
-	Info(msg string, keyvals ...interface{})
-	Warn(msg string, keyvals ...interface{})
-	Error(msg string, keyvals ...interface{})
+// WithLogger is an interface that prepend every log entry with keyvals.
+type WithLogger interface {
+	With(keyvals ...interface{}) Logger
 }

--- a/test/bindings_test.go
+++ b/test/bindings_test.go
@@ -37,7 +37,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 
 	"go.temporal.io/sdk/client"
-	"go.temporal.io/sdk/internal/log"
+	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 )
@@ -68,7 +68,7 @@ func (ts *AsyncBindingsTestSuite) SetupSuite() {
 	ts.client, err = client.NewClient(client.Options{
 		HostPort:  ts.config.ServiceAddr,
 		Namespace: namespace,
-		Logger:    log.NewDefaultLogger(),
+		Logger:    ilog.NewDefaultLogger(),
 	})
 	ts.NoError(err)
 	ts.registerNamespace()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -44,7 +44,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/interceptors"
-	"go.temporal.io/sdk/internal/log"
+	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
@@ -84,7 +84,7 @@ func (ts *IntegrationTestSuite) SetupSuite() {
 	ts.client, err = client.NewClient(client.Options{
 		HostPort:           ts.config.ServiceAddr,
 		Namespace:          namespace,
-		Logger:             log.NewDefaultLogger(),
+		Logger:             ilog.NewDefaultLogger(),
 		ContextPropagators: []workflow.ContextPropagator{NewStringMapPropagator([]string{testContextKey})},
 	})
 	ts.NoError(err)
@@ -398,7 +398,7 @@ func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyAbandon() {
 func (ts *IntegrationTestSuite) TestActivityCancelUsingReplay() {
 	replayer := worker.NewWorkflowReplayer()
 	replayer.RegisterWorkflowWithOptions(ts.workflows.ActivityCancelRepro, workflow.RegisterOptions{DisableAlreadyRegisteredCheck: true})
-	err := replayer.ReplayPartialWorkflowHistoryFromJSONFile(log.NewDefaultLogger(), "fixtures/activity.cancel.sm.repro.json", 12)
+	err := replayer.ReplayPartialWorkflowHistoryFromJSONFile(ilog.NewDefaultLogger(), "fixtures/activity.cancel.sm.repro.json", 12)
 	ts.NoError(err)
 }
 

--- a/test/replaytests/reply_test.go
+++ b/test/replaytests/reply_test.go
@@ -35,7 +35,7 @@ import (
 	"go.temporal.io/api/workflowservicemock/v1"
 
 	"go.temporal.io/sdk/client"
-	"go.temporal.io/sdk/internal/log"
+	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/worker"
 )
 
@@ -62,7 +62,7 @@ func (s *replayTestSuite) TearDownTest() {
 func (s *replayTestSuite) TestGenerateWorkflowHistory() {
 	s.T().Skip("Remove this Skip to regenerate the history.")
 	c, _ := client.NewClient(client.Options{
-		Logger: log.NewDefaultLogger(),
+		Logger: ilog.NewDefaultLogger(),
 	})
 	defer c.Close()
 
@@ -105,7 +105,7 @@ func (s *replayTestSuite) TestReplayWorkflowHistoryFromFile() {
 		replayer.RegisterWorkflow(Workflow1)
 		replayer.RegisterWorkflow(Workflow2)
 
-		err = replayer.ReplayWorkflowHistoryFromJSONFile(log.NewDefaultLogger(), testFile)
+		err = replayer.ReplayWorkflowHistoryFromJSONFile(ilog.NewDefaultLogger(), testFile)
 		require.NoError(s.T(), err, "file: %s", testFile)
 	}
 }
@@ -114,7 +114,7 @@ func (s *replayTestSuite) TestReplayBadWorkflowHistoryFromFile() {
 	replayer := worker.NewWorkflowReplayer()
 	replayer.RegisterWorkflow(Workflow1)
 
-	err := replayer.ReplayWorkflowHistoryFromJSONFile(log.NewDefaultLogger(), "bad-history.json")
+	err := replayer.ReplayWorkflowHistoryFromJSONFile(ilog.NewDefaultLogger(), "bad-history.json")
 	require.Error(s.T(), err)
 	require.True(s.T(), strings.HasPrefix(err.Error(), "replay workflow failed with failure"))
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -34,7 +34,7 @@ import (
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/internal"
-	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/workflow"
 )
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -34,7 +34,7 @@ import (
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/internal"
-	"go.temporal.io/sdk/internal/log"
+	ilog "go.temporal.io/sdk/internal/log"
 	"go.temporal.io/sdk/workflow"
 )
 

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -30,7 +30,7 @@ import (
 
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/internal"
-	ilog "go.temporal.io/sdk/internal/log"
+	"go.temporal.io/sdk/log"
 )
 
 type (

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -30,7 +30,7 @@ import (
 
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/internal"
-	"go.temporal.io/sdk/internal/log"
+	ilog "go.temporal.io/sdk/internal/log"
 )
 
 type (


### PR DESCRIPTION
Remove type aliasing for `Logger` and `WithLogger` interfaces.