### PR TITLE
Updates GO SDK to align with fixed Temporal Server Behavior for Child Workflow retries and timeouts

### DIFF
--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -36,7 +36,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 
 	"go.temporal.io/sdk/converter"
-	"go.temporal.io/sdk/internal/common/backoff"
 	"go.temporal.io/sdk/log"
 )
 
@@ -1457,9 +1456,7 @@ func convertRetryPolicy(retryPolicy *RetryPolicy) *commonpb.RetryPolicy {
 	if retryPolicy == nil {
 		return nil
 	}
-	if retryPolicy.BackoffCoefficient == 0 {
-		retryPolicy.BackoffCoefficient = backoff.DefaultBackoffCoefficient
-	}
+
 	return &commonpb.RetryPolicy{
 		MaximumInterval:        &retryPolicy.MaximumInterval,
 		InitialInterval:        &retryPolicy.InitialInterval,

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -284,7 +284,8 @@ func (w *Workflows) ChildWorkflowRetryOnError(ctx workflow.Context) error {
 func (w *Workflows) ChildWorkflowRetryOnTimeout(ctx workflow.Context) error {
 	opts := workflow.ChildWorkflowOptions{
 		WorkflowTaskTimeout:      time.Second,
-		WorkflowExecutionTimeout: time.Second,
+		WorkflowRunTimeout:       time.Second,
+		WorkflowExecutionTimeout: 30 * time.Second,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:    time.Second,
 			BackoffCoefficient: 2.0,


### PR DESCRIPTION
- Eliminates the setting of "2" as the default backoff co-efficient as the server does this.
- Updates the ChildWorkflowRetryOnTimeout test as retries now get exhausted when the WorkflowExecutionTimeout lapses (which was not occurring prior to the server fix)