### PR TITLE
Fix regression in Go SDK where Batch Timer interval for heartbeats is overcalculated

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1625,7 +1625,7 @@ func (i *temporalInvoker) Heartbeat(details *commonpb.Payloads, skipBatching boo
 		}
 
 		// We set a deadline at 80% of the timeout.
-		duration := time.Duration(0.8*float32(deadlineToTrigger)) * time.Second
+		duration := time.Duration(0.8 * float64(deadlineToTrigger))
 		i.hbBatchEndTimer = time.NewTimer(duration)
 
 		go func() {

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1324,7 +1324,9 @@ func (t *TaskHandlersTestSuite) TestHeartBeat_NoError() {
 	heartbeatErr := temporalInvoker.Heartbeat(nil, false)
 	t.NoError(heartbeatErr)
 
-	temporalInvoker.Heartbeat(nil, false)
+	heartbeatErr = temporalInvoker.Heartbeat(nil, false)
+	t.NoError(heartbeatErr)
+
 	time.Sleep(time.Second * 2)
 	t.Equal(2, recordActivityTaskCount, "batch timer did not execute")
 }

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -1327,7 +1327,7 @@ func (t *TaskHandlersTestSuite) TestHeartBeat_NoError() {
 	heartbeatErr = temporalInvoker.Heartbeat(nil, false)
 	t.NoError(heartbeatErr)
 
-	time.Sleep(time.Second * 2)
+	time.Sleep(time.Second * 3)
 	t.Equal(2, recordActivityTaskCount, "batch timer did not execute")
 }
 

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -85,6 +85,17 @@ func (a *Activities) HeartbeatAndSleep(ctx context.Context, seq int, delay time.
 	return seq, nil
 }
 
+func (a *Activities) LongRunningHeartbeat(ctx context.Context, delay time.Duration, recordHeartbeatDelay time.Duration) error {
+	a.append("longRunningHeartbeat")
+	endTime := time.Now().Add(delay)
+	for time.Now().Before(endTime) {
+		activity.RecordHeartbeat(ctx)
+		time.Sleep(recordHeartbeatDelay)
+	}
+
+	return nil
+}
+
 func (a *Activities) fail(_ context.Context) error {
 	a.append("fail")
 	return errFailOnPurpose

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -193,6 +193,13 @@ func (ts *IntegrationTestSuite) TestActivityRetryOnHBTimeout() {
 	ts.EqualValues(expected, ts.activities.invoked())
 }
 
+func (ts *IntegrationTestSuite) TestLongRunningActivityWithHB() {
+	var expected []string
+	err := ts.executeWorkflow("test-long-running-activity-with-hb", ts.workflows.LongRunningActivityWithHB, &expected)
+	ts.NoError(err)
+	ts.EqualValues(expected, ts.activities.invoked())
+}
+
 func (ts *IntegrationTestSuite) TestContinueAsNew() {
 	var result int
 	err := ts.executeWorkflow("test-continueasnew", ts.workflows.ContinueAsNew, &result, 4, ts.taskQueueName)

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -149,7 +149,7 @@ func (w *Workflows) LongRunningActivityWithHB(ctx workflow.Context) ([]string, e
 
 	err := workflow.ExecuteActivity(ctx, "LongRunningHeartbeat", 8*time.Second, 300*time.Millisecond).Get(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("expected activity to succeeded but it failed: %v", err)
+		return nil, fmt.Errorf("expected activity to succeed but it failed: %v", err)
 	}
 
 	return []string{"longRunningHeartbeat"}, nil


### PR DESCRIPTION
- As part of switching from variables representing time in seconds to time.Duration, we forgot to correctly update the line of code that calculates the interval for sending the next heartbeat. We were multiplying by an extra factor of one billion, which either caused an overflow (so that we were constantly sending heartbeats) or resulted in a large number (where we would never send a heartbeat after the first one).

Testing:
- Modified unit-test to validate that timer is fired and heartbeat is reported at least a second time.
- Added an integration test for a long-running activity with a smaller heartbeat timeout.