### PR TITLE
Rename cancelled to canceled for consistency

### DIFF
--- a/activity/activity.go
+++ b/activity/activity.go
@@ -67,7 +67,7 @@ func GetMetricsScope(ctx context.Context) tally.Scope {
 }
 
 // RecordHeartbeat sends heartbeat for the currently executing activity
-// If the activity is either cancelled (or) workflow/activity doesn't exist then we would cancel
+// If the activity is either canceled (or) workflow/activity doesn't exist then we would cancel
 // the context with error context.Canceled.
 //
 // details - the details that you provided here can be seen in the workflow when it receives TimeoutError, you

--- a/activity/doc.go
+++ b/activity/doc.go
@@ -114,8 +114,8 @@ payload containing progress information.
 
 Activity Cancellation
 
-When an activity is cancelled (or its workflow execution is completed or failed) the context passed into its function
-is cancelled which sets its Done channel’s closed state. So an activity can use that to perform any necessary cleanup
+When an activity is canceled (or its workflow execution is completed or failed) the context passed into its function
+is canceled which sets its Done channel’s closed state. So an activity can use that to perform any necessary cleanup
 and abort its execution. Currently cancellation is delivered only to activities that call RecordHeartbeat.
 
 Async/Manual Activity Completion

--- a/client/client.go
+++ b/client/client.go
@@ -190,7 +190,7 @@ type (
 		// activity Execute method can return activity.ErrResultPending to
 		// indicate the activity is not completed when it's Execute method returns. In that case, this CompleteActivity() method
 		// should be called when that activity is completed with the actual result and error. If err is nil, activity task
-		// completed event will be reported; if err is CanceledError, activity task cancelled event will be reported; otherwise,
+		// completed event will be reported; if err is CanceledError, activity task canceled event will be reported; otherwise,
 		// activity task failed event will be reported.
 		// An activity implementation should use GetActivityInfo(ctx).TaskToken function to get task token to use for completion.
 		// Example:-
@@ -206,7 +206,7 @@ type (
 		// activity Execute method can return activity.ErrResultPending to
 		// indicate the activity is not completed when it's Execute method returns. In that case, this CompleteActivityById() method
 		// should be called when that activity is completed with the actual result and error. If err is nil, activity task
-		// completed event will be reported; if err is CanceledError, activity task cancelled event will be reported; otherwise,
+		// completed event will be reported; if err is CanceledError, activity task canceled event will be reported; otherwise,
 		// activity task failed event will be reported.
 		// An activity implementation should use activityID provided in ActivityOption to use for completion.
 		// namespace name, workflowID, activityID are required, runID is optional.

--- a/internal/activity.go
+++ b/internal/activity.go
@@ -96,7 +96,7 @@ type (
 		// Optional: Default zero, means no heart beating is needed.
 		HeartbeatTimeout time.Duration
 
-		// WaitForCancellation - Whether to wait for cancelled activity to be completed(
+		// WaitForCancellation - Whether to wait for canceled activity to be completed(
 		// activity can be failed, completed, cancel accepted)
 		// Optional: default false
 		WaitForCancellation bool
@@ -194,9 +194,9 @@ func GetWorkerStopChannel(ctx context.Context) <-chan struct{} {
 }
 
 // RecordActivityHeartbeat sends heartbeat for the currently executing activity
-// If the activity is either cancelled (or) workflow/activity doesn't exist then we would cancel
+// If the activity is either canceled (or) workflow/activity doesn't exist then we would cancel
 // the context with error context.Canceled.
-//  TODO: we don't have a way to distinguish between the two cases when context is cancelled because
+//  TODO: we don't have a way to distinguish between the two cases when context is canceled because
 //  context doesn't support overriding value of ctx.Error.
 //  TODO: Implement automatic heartbeating with cancellation through ctx.
 // details - the details that you provided here can be seen in the worflow when it receives TimeoutError, you
@@ -227,7 +227,7 @@ func RecordActivityHeartbeat(ctx context.Context, details ...interface{}) {
 // ServiceInvoker abstracts calls to the Temporal service from an activity implementation.
 // Implement to unit test activities.
 type ServiceInvoker interface {
-	// Returns ActivityTaskCanceledError if activity is cancelled
+	// Returns ActivityTaskCanceledError if activity is canceled
 	Heartbeat(details *commonpb.Payloads, skipBatching bool) error
 	Close(flushBufferedHeartbeat bool)
 	GetClient(options ClientOptions) Client

--- a/internal/client.go
+++ b/internal/client.go
@@ -173,7 +173,7 @@ type (
 		// activity Execute method can return acitivity.activity.ErrResultPending to
 		// indicate the activity is not completed when it's Execute method returns. In that case, this CompleteActivity() method
 		// should be called when that activity is completed with the actual result and error. If err is nil, activity task
-		// completed event will be reported; if err is CanceledError, activity task cancelled event will be reported; otherwise,
+		// completed event will be reported; if err is CanceledError, activity task canceled event will be reported; otherwise,
 		// activity task failed event will be reported.
 		// An activity implementation should use GetActivityInfo(ctx).TaskToken function to get task token to use for completion.
 		// Example:-
@@ -189,7 +189,7 @@ type (
 		// activity Execute method can return activity.ErrResultPending to
 		// indicate the activity is not completed when it's Execute method returns. In that case, this CompleteActivityById() method
 		// should be called when that activity is completed with the actual result and error. If err is nil, activity task
-		// completed event will be reported; if err is CanceledError, activity task cancelled event will be reported; otherwise,
+		// completed event will be reported; if err is CanceledError, activity task canceled event will be reported; otherwise,
 		// activity task failed event will be reported.
 		// An activity implementation should use activityID provided in ActivityOption to use for completion.
 		// namespace name, workflowID, activityID are required, runID is optional.
@@ -444,7 +444,7 @@ type (
 		// after the current run is completed/failed/timeout. If a RetryPolicy is also supplied, and the workflow failed
 		// or timeout, the workflow will be retried based on the retry policy. While the workflow is retrying, it won't
 		// schedule its next run. If next schedule is due while workflow is running (or retrying), then it will skip that
-		// schedule. Cron workflow will not stop until it is terminated or cancelled (by returning temporal.CanceledError).
+		// schedule. Cron workflow will not stop until it is terminated or canceled (by returning temporal.CanceledError).
 		// The cron spec is as following:
 		// ┌───────────── minute (0 - 59)
 		// │ ┌───────────── hour (0 - 23)

--- a/internal/context.go
+++ b/internal/context.go
@@ -199,7 +199,7 @@ func WithCancel(parent Context) (ctx Context, cancel CancelFunc) {
 }
 
 // NewDisconnectedContext returns a new context that won't propagate parent's cancellation to the new child context.
-// One common use case is to do cleanup work after workflow is cancelled.
+// One common use case is to do cleanup work after workflow is canceled.
 //  err := workflow.ExecuteActivity(ctx, ActivityFoo).Get(ctx, &activityFooResult)
 //  if err != nil && temporal.IsCanceledError(ctx.Err()) {
 //    // activity failed, and workflow context is canceled

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1456,7 +1456,7 @@ func (wth *workflowTaskHandlerImpl) completeWorkflow(
 	var contErr *ContinueAsNewError
 
 	if errors.As(workflowContext.err, &canceledErr) {
-		// Workflow cancelled
+		// Workflow canceled
 		metricsScope.Counter(metrics.WorkflowCanceledCounter).Inc(1)
 		closeCommand = createNewCommand(enumspb.COMMAND_TYPE_CANCEL_WORKFLOW_EXECUTION)
 		closeCommand.Attributes = &commandpb.Command_CancelWorkflowExecutionCommandAttributes{CancelWorkflowExecutionCommandAttributes: &commandpb.CancelWorkflowExecutionCommandAttributes{
@@ -1609,11 +1609,11 @@ func (i *temporalInvoker) Heartbeat(details *commonpb.Payloads, skipBatching boo
 		return nil
 	}
 
-	isActivityCancelled, err := i.internalHeartBeat(details)
+	isActivityCanceled, err := i.internalHeartBeat(details)
 
-	// If the activity is cancelled, the activity can ignore the cancellation and do its work
+	// If the activity is canceled, the activity can ignore the cancellation and do its work
 	// and complete. Our cancellation is co-operative, so we will try to heartbeat.
-	if (err == nil || isActivityCancelled) && !skipBatching {
+	if (err == nil || isActivityCanceled) && !skipBatching {
 		// We have successfully sent heartbeat, start next batching window.
 		i.lastDetailsToReport = nil
 
@@ -1662,7 +1662,7 @@ func (i *temporalInvoker) Heartbeat(details *commonpb.Payloads, skipBatching boo
 }
 
 func (i *temporalInvoker) internalHeartBeat(details *commonpb.Payloads) (bool, error) {
-	isActivityCancelled := false
+	isActivityCanceled := false
 	timeout := i.heartBeatTimeout
 	if timeout <= 0 {
 		timeout = defaultHeartBeatInterval
@@ -1676,18 +1676,18 @@ func (i *temporalInvoker) internalHeartBeat(details *commonpb.Payloads) (bool, e
 	case *CanceledError:
 		// We are asked to cancel. inform the activity about cancellation through context.
 		i.cancelHandler()
-		isActivityCancelled = true
+		isActivityCanceled = true
 
 	case *serviceerror.NotFound, *serviceerror.NamespaceNotActive:
 		// We will pass these through as cancellation for now but something we can change
 		// later when we have setter on cancel handler.
 		i.cancelHandler()
-		isActivityCancelled = true
+		isActivityCanceled = true
 	}
 
 	// We don't want to bubble temporary errors to the user.
 	// This error won't be return to user check RecordActivityHeartbeat().
-	return isActivityCancelled, err
+	return isActivityCanceled, err
 }
 
 func (i *temporalInvoker) Close(flushBufferedHeartbeat bool) {

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -1041,11 +1041,11 @@ func convertActivityResultToRespondRequest(identity string, taskToken []byte, re
 			Identity:  identity}
 	}
 
-	var cancelledErr *CanceledError
-	if errors.As(err, &cancelledErr) {
+	var canceledErr *CanceledError
+	if errors.As(err, &canceledErr) {
 		return &workflowservice.RespondActivityTaskCanceledRequest{
 			TaskToken: taskToken,
-			Details:   convertErrDetailsToPayloads(cancelledErr.details, dataConverter),
+			Details:   convertErrDetailsToPayloads(canceledErr.details, dataConverter),
 			Identity:  identity}
 	}
 	if errors.Is(err, context.Canceled) {
@@ -1078,14 +1078,14 @@ func convertActivityResultToRespondRequestByID(identity, namespace, workflowID, 
 			Identity:   identity}
 	}
 
-	var cancelledErr *CanceledError
-	if errors.As(err, &cancelledErr) {
+	var canceledErr *CanceledError
+	if errors.As(err, &canceledErr) {
 		return &workflowservice.RespondActivityTaskCanceledByIdRequest{
 			Namespace:  namespace,
 			WorkflowId: workflowID,
 			RunId:      runID,
 			ActivityId: activityID,
-			Details:    convertErrDetailsToPayloads(cancelledErr.details, dataConverter),
+			Details:    convertErrDetailsToPayloads(canceledErr.details, dataConverter),
 			Identity:   identity}
 	}
 

--- a/internal/internal_time.go
+++ b/internal/internal_time.go
@@ -44,7 +44,7 @@ type (
 		Now() time.Time
 
 		// NewTimer - Creates a new timer that will fire callback after d(resolution is in seconds).
-		// The callback indicates the error(TimerCanceledError) if the timer is cancelled.
+		// The callback indicates the error(TimerCanceledError) if the timer is canceled.
 		NewTimer(d time.Duration, callback ResultHandler) *TimerInfo
 
 		// RequestCancelTimer - Requests cancel of a timer, this one doesn't wait for cancellation request

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1609,7 +1609,7 @@ func TestActivityErrorWithDetailsWithDataConverter(t *testing.T) {
 	testActivityErrorWithDetailsHelper(ctx, t, dc)
 }
 
-func testActivityCancelledErrorHelper(ctx context.Context, t *testing.T, dataConverter converter.DataConverter) {
+func testActivityCanceledErrorHelper(ctx context.Context, t *testing.T, dataConverter converter.DataConverter) {
 	a1 := activityExecutor{
 		name: "test",
 		fn: func(arg1 int) (err error) {
@@ -1666,10 +1666,10 @@ func testActivityCancelledErrorHelper(ctx context.Context, t *testing.T, dataCon
 	require.Equal(t, testErrorDetails{T: "testErrorStack4"}, td)
 }
 
-func TestActivityCancelledErrorWithDataConverter(t *testing.T) {
+func TestActivityCanceledErrorWithDataConverter(t *testing.T) {
 	dc := iconverter.NewTestDataConverter()
 	ctx := context.WithValue(context.Background(), activityEnvContextKey, &activityEnvironment{dataConverter: dc})
-	testActivityCancelledErrorHelper(ctx, t, dc)
+	testActivityCanceledErrorHelper(ctx, t, dc)
 }
 
 func testActivityExecutionVariousTypesHelper(ctx context.Context, t *testing.T, dataConverter converter.DataConverter) {

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -507,7 +507,7 @@ func (d *syncWorkflowDefinition) Execute(env WorkflowEnvironment, header *common
 
 	getWorkflowEnvironment(d.rootCtx).RegisterCancelHandler(func() {
 		// It is ok to call this method multiple times.
-		// it doesn't do anything new, the context remains cancelled.
+		// it doesn't do anything new, the context remains canceled.
 		d.cancel()
 	})
 

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -576,7 +576,7 @@ func isEntityNotFoundFromPassive(err error) bool {
 // CompleteActivity reports activity completed. activity Execute method can return activity.ErrResultPending to
 // indicate the activity is not completed when it's Execute method returns. In that case, this CompleteActivity() method
 // should be called when that activity is completed with the actual result and error. If err is nil, activity task
-// completed event will be reported; if err is CanceledError, activity task cancelled event will be reported; otherwise,
+// completed event will be reported; if err is CanceledError, activity task canceled event will be reported; otherwise,
 // activity task failed event will be reported.
 func (wc *WorkflowClient) CompleteActivity(ctx context.Context, taskToken []byte, result interface{}, err error) error {
 	if taskToken == nil {

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -640,7 +640,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoIdInOptions_RawHistory() {
 	s.Equal(workflowRun.GetID(), wid)
 }
 
-func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Cancelled() {
+func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Canceled() {
 	createResponse := &workflowservice.StartWorkflowExecutionResponse{
 		RunId: runID,
 	}

--- a/internal/internal_workflow_test.go
+++ b/internal/internal_workflow_test.go
@@ -454,7 +454,7 @@ func (s *WorkflowUnitTest) Test_ContinueAsNewWorkflow() {
 
 func cancelWorkflowTest(ctx Context) (string, error) {
 	if ctx.Done().Receive(ctx, nil); ctx.Err() == ErrCanceled {
-		return "Cancelled.", ctx.Err()
+		return "Canceled.", ctx.Err()
 	}
 	return "Completed.", nil
 }
@@ -491,7 +491,7 @@ func cancelWorkflowAfterActivityTest(ctx Context) ([]byte, error) {
 	}
 
 	if ctx.Done().Receive(ctx, nil); ctx.Err() == ErrCanceled {
-		return []byte("Cancelled."), ctx.Err()
+		return []byte("Canceled."), ctx.Err()
 	}
 	return []byte("Completed."), nil
 }

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -342,7 +342,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowActivityCancellation() {
 			cancelHandler()
 		}).Select(ctx)
 
-		err := f2.Get(ctx, nil) // verify slow activity is cancelled
+		err := f2.Get(ctx, nil) // verify slow activity is canceled
 		if _, ok := err.(*CanceledError); !ok {
 			return err
 		}
@@ -353,7 +353,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowActivityCancellation() {
 	env.RegisterWorkflow(workflowFn)
 	env.RegisterActivity(testActivityHeartbeat)
 	activityMap := make(map[string]string) // msg -> activityID
-	var completedActivityID, cancelledActivityID string
+	var completedActivityID, canceledActivityID string
 	env.SetOnActivityStartedListener(func(activityInfo *ActivityInfo, ctx context.Context, args converter.EncodedValues) {
 		var msg string
 		s.NoError(args.Get(&msg))
@@ -363,14 +363,14 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowActivityCancellation() {
 		completedActivityID = activityInfo.ActivityID
 	})
 	env.SetOnActivityCanceledListener(func(activityInfo *ActivityInfo) {
-		cancelledActivityID = activityInfo.ActivityID
+		canceledActivityID = activityInfo.ActivityID
 	})
 	env.ExecuteWorkflow(workflowFn)
 
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
 	s.Equal(activityMap["fast"], completedActivityID)
-	s.Equal(activityMap["slow"], cancelledActivityID)
+	s.Equal(activityMap["slow"], canceledActivityID)
 }
 
 func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithUserContext() {
@@ -564,10 +564,10 @@ func testActivityHeartbeat(ctx context.Context, msg string, waitTime time.Durati
 		RecordActivityHeartbeat(ctx)
 		select {
 		case <-ctx.Done():
-			// We have been cancelled.
+			// We have been canceled.
 			return "", ctx.Err()
 		default:
-			// We are not cancelled yet.
+			// We are not canceled yet.
 		}
 
 		sleepDuration := time.Second
@@ -1837,16 +1837,16 @@ func (s *WorkflowTestSuiteUnitTest) Test_LocalActivity() {
 }
 
 func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListeners() {
-	var localActivityFnCancelled atomic.Bool
+	var localActivityFnCanceled atomic.Bool
 	var startedCount, completedCount, canceledCount atomic.Int32
 
 	localActivityFn := func(_ context.Context, _ string) (string, error) {
 		panic("this won't be called because it is mocked")
 	}
 
-	cancelledLocalActivityFn := func(ctx context.Context) error {
+	canceledLocalActivityFn := func(ctx context.Context) error {
 		<-ctx.Done()
-		localActivityFnCancelled.Store(true)
+		localActivityFnCanceled.Store(true)
 		return nil
 	}
 
@@ -1856,7 +1856,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListene
 		f := ExecuteLocalActivity(ctx, localActivityFn, "local_activity")
 
 		ctx2, cancel := WithCancel(ctx)
-		f2 := ExecuteLocalActivity(ctx2, cancelledLocalActivityFn)
+		f2 := ExecuteLocalActivity(ctx2, canceledLocalActivityFn)
 
 		err := f.Get(ctx, nil)
 		if err != nil {
@@ -1905,7 +1905,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListene
 	s.Equal(int32(1), completedCount.Load())
 	s.Equal(int32(1), canceledCount.Load())
 	s.Equal("hello mock", result)
-	s.True(localActivityFnCancelled.Load())
+	s.True(localActivityFnCanceled.Load())
 }
 
 func (s *WorkflowTestSuiteUnitTest) Test_SignalChildWorkflow() {

--- a/internal/session.go
+++ b/internal/session.go
@@ -156,9 +156,9 @@ var (
 // executing the session is down, that session will be marked as failed. Executing an activity
 // within a failed session will return ErrSessionFailed immediately without scheduling that activity.
 //
-// The returned session Context will be cancelled if the session fails (worker died) or CompleteSession()
+// The returned session Context will be canceled if the session fails (worker died) or CompleteSession()
 // is called. This means that in these two cases, all user activities scheduled using the returned session
-// Context will also be cancelled.
+// Context will also be canceled.
 //
 // If user wants to end a session since activity returns some error, use CompleteSession API below.
 // New session can be created if necessary to retry the whole session.
@@ -222,13 +222,13 @@ func CompleteSession(ctx Context) {
 	// this will cancel the ctx passed into this function
 	sessionInfo.sessionCancelFunc()
 
-	// then execute then completion activity using the completionCtx, which is not cancelled.
+	// then execute then completion activity using the completionCtx, which is not canceled.
 	completionCtx := WithActivityOptions(sessionInfo.completionCtx, ActivityOptions{
 		ScheduleToStartTimeout: time.Second * 3,
 		StartToCloseTimeout:    time.Second * 3,
 	})
 
-	// even though the creation activity has been cancelled, the session worker doesn't know. The worker will wait until
+	// even though the creation activity has been canceled, the session worker doesn't know. The worker will wait until
 	// next heartbeat to figure out that the workflow is completed and then release the resource. We need to make sure the
 	// completion activity is executed before the workflow exits.
 	// the taskqueue will be overrided to use the one stored in sessionInfo.
@@ -429,7 +429,7 @@ func sessionCreationActivity(ctx context.Context, sessionID string) error {
 			isRetryable := func(_ error) bool {
 				// there will be two types of error here:
 				// 1. transient errors like timeout, in which case we should not fail the session
-				// 2. non-retryable errors like activity cancelled, activity not found or domain
+				// 2. non-retryable errors like activity canceled, activity not found or domain
 				// not active. In those cases, the internal implementation will cancel the context,
 				// so in the next iteration, ctx.Done() will be selected. Here we rely on the heartbeat
 				// internal implementation to tell which error is non-retryable.

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -197,7 +197,7 @@ type (
 		// Optional: default is 10s if this is not provided (or if 0 is provided).
 		WorkflowTaskTimeout time.Duration
 
-		// WaitForCancellation - Whether to wait for cancelled child workflow to be ended (child workflow can be ended
+		// WaitForCancellation - Whether to wait for canceled child workflow to be ended (child workflow can be ended
 		// as: completed/failed/timedout/terminated/canceled)
 		// Optional: default false
 		WaitForCancellation bool
@@ -215,7 +215,7 @@ type (
 		// after the current run is completed/failed/timeout. If a RetryPolicy is also supplied, and the workflow failed
 		// or timeout, the workflow will be retried based on the retry policy. While the workflow is retrying, it won't
 		// schedule its next run. If next schedule is due while workflow is running (or retrying), then it will skip that
-		// schedule. Cron workflow will not stop until it is terminated or cancelled (by returning temporal.CanceledError).
+		// schedule. Cron workflow will not stop until it is terminated or canceled (by returning temporal.CanceledError).
 		// The cron spec is as following:
 		// ┌───────────── minute (0 - 59)
 		// │ ┌───────────── hour (0 - 23)
@@ -258,7 +258,7 @@ func Await(ctx Context, condition func() bool) error {
 		// TODO: Consider always returning a channel
 		if doneCh != nil {
 			if _, more := doneCh.ReceiveAsyncWithMoreFlag(nil); !more {
-				return NewCanceledError("Await context cancelled")
+				return NewCanceledError("Await context canceled")
 			}
 		}
 		state.yield("Await")
@@ -277,7 +277,7 @@ func AwaitWithTimeout(ctx Context, timeout time.Duration, condition func() bool)
 		// TODO: Consider always returning a channel
 		if doneCh != nil {
 			if _, more := doneCh.ReceiveAsyncWithMoreFlag(nil); !more {
-				return false, NewCanceledError("AwaitWithTimeout context cancelled")
+				return false, NewCanceledError("AwaitWithTimeout context canceled")
 			}
 		}
 		if timer.IsReady() {
@@ -690,11 +690,11 @@ func (wc *workflowEnvironmentInterceptor) ExecuteChildWorkflow(ctx Context, chil
 		if e == nil {
 			// We must wait for Workflow initiation to finish before registering the cancellation handler.
 			// Otherwise, we risk firing the cancel handler and then having the workflow "initiate" afterwards,
-			// which would result in an uncancelled workflow.
+			// which would result in an uncanceled workflow.
 			if cancellable {
 				cancellationCallback.fn = func(v interface{}, _ bool) bool {
 					if ctx.Err() == ErrCanceled && !mainFuture.IsReady() {
-						// child workflow started, and ctx cancelled
+						// child workflow started, and ctx canceled
 						getWorkflowEnvironment(ctx).RequestCancelChildWorkflow(options.Namespace, r.ID)
 					}
 					return false

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -610,9 +610,9 @@ func (e *TestWorkflowEnvironment) SetOnTimerFiredListener(listener func(timerID 
 	return e
 }
 
-// SetOnTimerCancelledListener sets a listener that will be called after a timer is cancelled
-func (e *TestWorkflowEnvironment) SetOnTimerCancelledListener(listener func(timerID string)) *TestWorkflowEnvironment {
-	e.impl.onTimerCancelledListener = listener
+// SetOnTimerCanceledListener sets a listener that will be called after a timer is canceled
+func (e *TestWorkflowEnvironment) SetOnTimerCanceledListener(listener func(timerID string)) *TestWorkflowEnvironment {
+	e.impl.onTimerCanceledListener = listener
 	return e
 }
 

--- a/temporal/error.go
+++ b/temporal/error.go
@@ -173,7 +173,7 @@ func NewNonRetryableApplicationError(message, errType string, cause error, detai
 }
 
 // NewCanceledError creates CanceledError instance.
-// Return this error from activity or child workflow to indicate that it was successfully cancelled.
+// Return this error from activity or child workflow to indicate that it was successfully canceled.
 func NewCanceledError(details ...interface{}) *CanceledError {
 	return internal.NewCanceledError(details...)
 }

--- a/workflow/context.go
+++ b/workflow/context.go
@@ -68,7 +68,7 @@ func WithValue(parent Context, key interface{}, val interface{}) Context {
 }
 
 // NewDisconnectedContext returns a new context that won't propagate parent's cancellation to the new child context.
-// One common use case is to do cleanup work after workflow is cancelled.
+// One common use case is to do cleanup work after workflow is canceled.
 //  err := workflow.ExecuteActivity(ctx, ActivityFoo).Get(ctx, &activityFooResult)
 //  if err != nil && temporal.IsCanceledError(ctx.Err()) {
 //    // activity failed, and workflow context is canceled

--- a/workflow/session.go
+++ b/workflow/session.go
@@ -75,9 +75,9 @@ var ErrSessionFailed = internal.ErrSessionFailed
 // executing the session is down, that session will be marked as failed. Executing an activity
 // within a failed session will return ErrSessionFailed immediately without scheduling that activity.
 //
-// The returned session Context will be cancelled if the session fails (worker died) or CompleteSession()
+// The returned session Context will be canceled if the session fails (worker died) or CompleteSession()
 // is called. This means that in these two cases, all user activities scheduled using the returned session
-// Context will also be cancelled.
+// Context will also be canceled.
 //
 // If user wants to end a session since activity returns some error, use CompleteSession API below.
 // New session can be created if necessary to retry the whole session.


### PR DESCRIPTION
Let's use US form everywhere: https://www.dictionary.com/e/canceled-vs-cancelled/.