### PR TITLE
Use a separate counter for local activity

### DIFF
--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -820,12 +820,12 @@ func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_LocalActivity_Result
 
 		createTestEventLocalActivity(5, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   localActivityMarkerName,
-			Details:                      s.createLocalActivityMarkerDataForTest("5"),
+			Details:                      s.createLocalActivityMarkerDataForTest("1"),
 			WorkflowTaskCompletedEventId: 4,
 		}),
 		createTestEventLocalActivity(6, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   localActivityMarkerName,
-			Details:                      s.createLocalActivityMarkerDataForTest("6"),
+			Details:                      s.createLocalActivityMarkerDataForTest("2"),
 			WorkflowTaskCompletedEventId: 4,
 		}),
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -298,12 +298,12 @@ func (s *internalWorkerTestSuite) TestReplayWorkflowHistory_LocalActivity() {
 
 		createTestEventLocalActivity(5, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   localActivityMarkerName,
-			Details:                      s.createLocalActivityMarkerDataForTest("5"),
+			Details:                      s.createLocalActivityMarkerDataForTest("1"),
 			WorkflowTaskCompletedEventId: 4,
 		}),
 		createTestEventLocalActivity(6, &historypb.MarkerRecordedEventAttributes{
 			MarkerName:                   localActivityMarkerName,
-			Details:                      s.createLocalActivityMarkerDataForTest("6"),
+			Details:                      s.createLocalActivityMarkerDataForTest("2"),
 			WorkflowTaskCompletedEventId: 4,
 		}),
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -475,6 +475,10 @@ func (ts *IntegrationTestSuite) TestWorkflowWithLocalActivityCtxPropagation() {
 	ts.EqualValues(expected, "test-data-in-contexttest-data-in-context")
 }
 
+func (ts *IntegrationTestSuite) TestWorkflowWithParallelLocalActivities() {
+	ts.NoError(ts.executeWorkflow("test-wf-parallel-local-activities", ts.workflows.WorkflowWithParallelLocalActivities, nil))
+}
+
 func (ts *IntegrationTestSuite) TestLargeQueryResultError() {
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()


### PR DESCRIPTION
We cannot use ID generator used for command processing as it is 
only incremented when command is actually generated.  In the case 
of local activity, command is generated when the local activity 
completes.  This results in multiple invocations of LocalActivity in the 
same workflow task processing to potentially use the same id.  This
results in only one local activity to be processed and all others are 
ignored.
Created a separate counter which is used for unique id generation 
for local activities.  There may be more places which needs to be
moved to this counter instead of the id generator used for command
processing.