### PR TITLE
Fixes flaky integration-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ default: check test
 # general build-product folder, cleaned as part of `make clean`
 BUILD := .build
 
-TEST_TIMEOUT := 2m
+TEST_TIMEOUT := 3m
 TEST_ARG ?= -race -v -timeout $(TEST_TIMEOUT)
 
 INTEG_TEST_ROOT := ./test

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -170,7 +170,7 @@ func (w *Workflows) ActivityRetryOnHBTimeout(ctx workflow.Context) ([]string, er
 	}
 
 	elapsed := workflow.Now(ctx).Sub(startTime)
-	if elapsed < opts.StartToCloseTimeout-opts.RetryPolicy.MaximumInterval {
+	if elapsed < opts.ScheduleToCloseTimeout-opts.RetryPolicy.MaximumInterval {
 		return nil, fmt.Errorf("expected activity to be retried on failure, but it was not. Elapsed time: %d", elapsed.Milliseconds())
 	}
 

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -170,6 +170,10 @@ func (w *Workflows) ActivityRetryOnHBTimeout(ctx workflow.Context) ([]string, er
 	}
 
 	elapsed := workflow.Now(ctx).Sub(startTime)
+
+	// We keep retrying the activity until either schedule-to-close has elapsed or the next scheduled retry
+	// takes us beyond the schedule-to-close time limit. Therefore, if retry on HB happened, we expected
+	// elapsed time to be at least the value below.
 	if elapsed < opts.ScheduleToCloseTimeout-opts.RetryPolicy.MaximumInterval {
 		return nil, fmt.Errorf("expected activity to be retried on failure, but it was not. Elapsed time: %d", elapsed.Milliseconds())
 	}

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -170,7 +170,7 @@ func (w *Workflows) ActivityRetryOnHBTimeout(ctx workflow.Context) ([]string, er
 	}
 
 	elapsed := workflow.Now(ctx).Sub(startTime)
-	if elapsed < 5*time.Second {
+	if elapsed < opts.StartToCloseTimeout-opts.RetryPolicy.MaximumInterval {
 		return nil, fmt.Errorf("expected activity to be retried on failure, but it was not. Elapsed time: %d", elapsed.Milliseconds())
 	}
 


### PR DESCRIPTION
1) Address flakiness in ActivityHBTimeout Test:
The test was validating that the full 5 seconds of the schedule-to-close time had elapsed before the activity failed.
This is actually incorrect as we will abort the retry early if the current time + current_retry_interval exceeds the schedule-to-close deadline. As a result, this could cause flakiness as the activity would fail after 4+ seconds (not bother doing the last retry since that would exceed the overall deadline). Fixes this to change the threshold to remove the maximum interval

2) Addresses flakiness in overall integration test:
The overall integration test timeout was 2 minutes. We've added new tests since that time and now we are running up against the limit on certain environments. Increasing the timeout to 3 minutes to account for the new tests