### PR TITLE
Tune gRPC connection timeouts

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -559,10 +559,10 @@ func NewClient(options ClientOptions) (Client, error) {
 
 func newDialParameters(options *ClientOptions) dialParameters {
 	return dialParameters{
-		UserOptions:          options.ConnectionOptions,
-		HostPort:             options.HostPort,
-		RequiredInterceptors: requiredInterceptors(options.MetricsScope),
-		DefaultServiceConfig: defaultServiceConfig,
+		UserConnectionOptions: options.ConnectionOptions,
+		HostPort:              options.HostPort,
+		RequiredInterceptors:  requiredInterceptors(options.MetricsScope),
+		DefaultServiceConfig:  defaultServiceConfig,
 	}
 }
 

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -66,7 +66,7 @@ func dial(params dialParameters) (*grpc.ClientConn, error) {
 	// If connection goes does gRPC will try to reconnect using exponential backoff strategy:
 	// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
 	// Default MaxDelay is 120 seconds which is too high.
-	// Setting it to retryPollOperationMaxInterval here will correleate with poll reconnect interval.
+	// Setting it to retryPollOperationMaxInterval here will correlate with poll reconnect interval.
 	var cp = grpc.ConnectParams{
 		Backoff: backoff.DefaultConfig,
 	}

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -62,8 +62,8 @@ func dial(params dialParameters) (*grpc.ClientConn, error) {
 	}
 
 	// gRPC maintains connection pool inside grpc.ClientConn.
-	// This connection pool has automatic reconnect feature.
-	// If connection goes does gRPC will try to reconnect using exponential backoff strategy:
+	// This connection pool has auto reconnect feature.
+	// If connection goes down, gRPC will try to reconnect using exponential backoff strategy:
 	// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
 	// Default MaxDelay is 120 seconds which is too high.
 	// Setting it to retryPollOperationMaxInterval here will correlate with poll reconnect interval.

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -52,7 +52,10 @@ import (
 )
 
 const (
-	pollTaskServiceTimeOut = 150 * time.Second // Server long poll is 2 * Minutes + delta
+	// Server returns empty task after dynamicconfig.MatchingLongPollExpirationInterval (default is 60 seconds).
+	// pollTaskServiceTimeOut should be dynamicconfig.MatchingLongPollExpirationInterval + some delta for full round trip to matching
+	// because empty task should be returned before timeout is expired (expired timeout counts against SLO).
+	pollTaskServiceTimeOut = 70 * time.Second
 
 	stickyWorkflowTaskScheduleToStartTimeoutSeconds = 5
 

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -54,9 +54,9 @@ const (
 
 	// defaultRPCTimeout is the default gRPC call timeout.
 	defaultRPCTimeout = 10 * time.Second
-	// minRPCTimeout is minimum gRP call timeout allowed.
+	// minRPCTimeout is minimum gRPC call timeout allowed.
 	minRPCTimeout = 1 * time.Second
-	// maxRPCTimeout is maximum gRPC call timeout allowed (should not be less then defaultRPCTimeout).
+	// maxRPCTimeout is maximum gRPC call timeout allowed (should not be less than defaultRPCTimeout).
 	maxRPCTimeout = 10 * time.Second
 )
 

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -52,12 +52,12 @@ const (
 	clientImplHeaderName  = "temporal-client-name"
 	clientImplHeaderValue = "temporal-go"
 
-	// defaultRPCTimeout is the default gRPC rpc call timeout
+	// defaultRPCTimeout is the default gRPC call timeout.
 	defaultRPCTimeout = 10 * time.Second
-	// minRPCTimeout is minimum rpc call timeout allowed
+	// minRPCTimeout is minimum gRP call timeout allowed.
 	minRPCTimeout = 1 * time.Second
-	// maxRPCTimeout is maximum rpc call timeout allowed
-	maxRPCTimeout = 5 * time.Second
+	// maxRPCTimeout is maximum gRPC call timeout allowed (should not be less then defaultRPCTimeout).
+	maxRPCTimeout = 10 * time.Second
 )
 
 // grpcContextBuilder stores all gRPC-specific parameters that will


### PR DESCRIPTION
When connection to server is lost and then restored it might take up to 120 seconds for the client to make a successful request due to internal gRPC reconnect implementation. This PR changes this default to 10 seconds and tunes few other timeouts.