### PR TITLE
grpc.WithConnectParams was added without set MinConnectTimeout 

### DIFF
--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -69,6 +69,7 @@ func dial(params dialParameters) (*grpc.ClientConn, error) {
 	// Setting it to retryPollOperationMaxInterval here will correlate with poll reconnect interval.
 	var cp = grpc.ConnectParams{
 		Backoff: backoff.DefaultConfig,
+		MinConnectTimeout: minConnectTimeout,
 	}
 	cp.Backoff.BaseDelay = retryPollOperationInitialInterval
 	cp.Backoff.MaxDelay = retryPollOperationMaxInterval

--- a/internal/internal_worker_base.go
+++ b/internal/internal_worker_base.go
@@ -49,6 +49,8 @@ import (
 const (
 	retryPollOperationInitialInterval = 20 * time.Millisecond
 	retryPollOperationMaxInterval     = 10 * time.Second
+
+	minConnectTimeout = 20 * time.Second
 )
 
 var (


### PR DESCRIPTION
gRPC backoff was added to file `grpc_dialer.go` at version v0.30.0. Func `grpc.WithConnectParams` will set `option.minConnectTimeout` to the func with return value `ConnectParams.MinConnectTimeout`, which has default value `minConnectTimeout = 20 * time.Second`.
But now we are not passing `MinConnectTimeout` to the parameter used by `grpc.WithConnectParams`, so the **func is set** and **use zero value**.

In that way, `grpc.Dial()` is easy to fail. `ConnectParams.MinConnectTimeout` should be set to the old 20 seconds default.

