### PR TITLE
Fixes memory leaks found during stress testing

### DIFF
--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -641,6 +641,10 @@ func (wc *workflowEnvironmentImpl) SideEffect(f func() (*commonpb.Payloads, erro
 			panic(fmt.Sprintf("No cached result found for side effectID=%v. KnownSideEffects=%v",
 				sideEffectID, keys))
 		}
+
+		// Once the Side effect has been consumed, we can free the referenced payload
+		// to save on memory pressure
+		delete(wc.sideEffectResult, sideEffectID)
 		wc.logger.Debug("SideEffect returning already calculated result.",
 			tagSideEffectID, sideEffectID)
 	} else {

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -642,8 +642,8 @@ func (wc *workflowEnvironmentImpl) SideEffect(f func() (*commonpb.Payloads, erro
 				sideEffectID, keys))
 		}
 
-		// Once the Side effect has been consumed, we can free the referenced payload
-		// to save on memory pressure
+		// Once the SideEffect has been consumed, we can free the referenced payload
+		// to reduce memory pressure
 		delete(wc.sideEffectResult, sideEffectID)
 		wc.logger.Debug("SideEffect returning already calculated result.",
 			tagSideEffectID, sideEffectID)

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -364,7 +364,14 @@ OrderEvents:
 	}
 
 	// shrink loaded events so it can be GCed
-	eh.loadedEvents = append([]*historypb.HistoryEvent{nil}, eh.loadedEvents[eh.currentIndex:]...)
+	eh.loadedEvents = append(
+		make(
+			[]*historypb.HistoryEvent,
+			0,
+			len(eh.loadedEvents)-eh.currentIndex),
+		eh.loadedEvents[eh.currentIndex:]...,
+	)
+
 	eh.currentIndex = 0
 
 	return nextEvents, markers, nil

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -364,7 +364,7 @@ OrderEvents:
 	}
 
 	// shrink loaded events so it can be GCed
-	eh.loadedEvents = eh.loadedEvents[eh.currentIndex:]
+	eh.loadedEvents = append([]*historypb.HistoryEvent{nil}, eh.loadedEvents[eh.currentIndex:]...)
 	eh.currentIndex = 0
 
 	return nextEvents, markers, nil


### PR DESCRIPTION
- Code to proactively cleanup loaded history during pagination was not actually reducing memory pressure as the underlying slice does not shrink when taking sub-slices.
- Holding onto side effect payloads after they have been processed provides no benefit and just eats memory. We can just delete the entry once we've served the SideEffect value.