### PR TITLE
Remove WorkerWorkflowTasksPerSecond WorkerOption

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -146,9 +146,6 @@ type (
 		// Defines how many concurrent workflow task executions by this worker.
 		ConcurrentWorkflowTaskExecutionSize int
 
-		// Defines rate limiting on number of workflow tasks that can be executed per second per worker.
-		WorkerWorkflowTasksPerSecond float64
-
 		// MaxConcurrentWorkflowTaskQueuePollers is the max number of pollers for workflow task queue.
 		MaxConcurrentWorkflowTaskQueuePollers int
 
@@ -283,7 +280,7 @@ func newWorkflowTaskWorkerInternal(taskHandler WorkflowTaskHandler, service work
 		pollerCount:       params.MaxConcurrentWorkflowTaskQueuePollers,
 		pollerRate:        defaultPollerRate,
 		maxConcurrentTask: params.ConcurrentWorkflowTaskExecutionSize,
-		maxTaskPerSecond:  params.WorkerWorkflowTasksPerSecond,
+		maxTaskPerSecond:  defaultWorkerTaskExecutionRate,
 		taskWorker:        poller,
 		identity:          params.Identity,
 		workerType:        "WorkflowWorker",
@@ -1254,7 +1251,6 @@ func NewAggregatedWorker(client *WorkflowClient, taskQueue string, options Worke
 		ConcurrentLocalActivityExecutionSize:  options.MaxConcurrentLocalActivityExecutionSize,
 		WorkerLocalActivitiesPerSecond:        options.WorkerLocalActivitiesPerSecond,
 		ConcurrentWorkflowTaskExecutionSize:   options.MaxConcurrentWorkflowTaskExecutionSize,
-		WorkerWorkflowTasksPerSecond:          options.WorkerWorkflowTasksPerSecond,
 		MaxConcurrentWorkflowTaskQueuePollers: options.MaxConcurrentWorkflowTaskPollers,
 		Identity:                              client.identity,
 		MetricsScope:                          client.metricsScope,
@@ -1431,9 +1427,6 @@ func setWorkerOptionsDefaults(options *WorkerOptions) {
 	}
 	if options.MaxConcurrentWorkflowTaskExecutionSize == 0 {
 		options.MaxConcurrentWorkflowTaskExecutionSize = defaultMaxConcurrentTaskExecutionSize
-	}
-	if options.WorkerWorkflowTasksPerSecond == 0 {
-		options.WorkerWorkflowTasksPerSecond = defaultWorkerTaskExecutionRate
 	}
 	if options.MaxConcurrentWorkflowTaskPollers <= 0 {
 		options.MaxConcurrentWorkflowTaskPollers = defaultConcurrentPollRoutineSize

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1853,7 +1853,6 @@ func TestWorkerOptionDefaults(t *testing.T) {
 		ConcurrentActivityExecutionSize:       defaultMaxConcurrentActivityExecutionSize,
 		ConcurrentWorkflowTaskExecutionSize:   defaultMaxConcurrentTaskExecutionSize,
 		WorkerActivitiesPerSecond:             defaultTaskQueueActivitiesPerSecond,
-		WorkerWorkflowTasksPerSecond:          defaultWorkerTaskExecutionRate,
 		TaskQueueActivitiesPerSecond:          defaultTaskQueueActivitiesPerSecond,
 		WorkerLocalActivitiesPerSecond:        defaultWorkerLocalActivitiesPerSecond,
 		StickyScheduleToStartTimeout:          stickyWorkflowTaskScheduleToStartTimeoutSeconds * time.Second,
@@ -1899,7 +1898,6 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 		MaxConcurrentWorkflowTaskPollers:        11,
 		MaxConcurrentActivityTaskPollers:        12,
 		WorkerLocalActivitiesPerSecond:          222,
-		WorkerWorkflowTasksPerSecond:            111,
 		WorkerActivitiesPerSecond:               99,
 		StickyScheduleToStartTimeout:            555 * time.Minute,
 		BackgroundActivityContext:               context.Background(),
@@ -1918,7 +1916,6 @@ func TestWorkerOptionNonDefaults(t *testing.T) {
 		ConcurrentActivityExecutionSize:       options.MaxConcurrentActivityExecutionSize,
 		ConcurrentWorkflowTaskExecutionSize:   options.MaxConcurrentWorkflowTaskExecutionSize,
 		WorkerActivitiesPerSecond:             options.WorkerActivitiesPerSecond,
-		WorkerWorkflowTasksPerSecond:          options.WorkerWorkflowTasksPerSecond,
 		TaskQueueActivitiesPerSecond:          options.TaskQueueActivitiesPerSecond,
 		WorkerLocalActivitiesPerSecond:        options.WorkerLocalActivitiesPerSecond,
 		StickyScheduleToStartTimeout:          options.StickyScheduleToStartTimeout,
@@ -1945,7 +1942,6 @@ func assertWorkerExecutionParamsEqual(t *testing.T, paramsA workerExecutionParam
 	require.Equal(t, paramsA.ConcurrentActivityExecutionSize, paramsB.ConcurrentActivityExecutionSize)
 	require.Equal(t, paramsA.ConcurrentWorkflowTaskExecutionSize, paramsB.ConcurrentWorkflowTaskExecutionSize)
 	require.Equal(t, paramsA.WorkerActivitiesPerSecond, paramsB.WorkerActivitiesPerSecond)
-	require.Equal(t, paramsA.WorkerWorkflowTasksPerSecond, paramsB.WorkerWorkflowTasksPerSecond)
 	require.Equal(t, paramsA.TaskQueueActivitiesPerSecond, paramsB.TaskQueueActivitiesPerSecond)
 	require.Equal(t, paramsA.StickyScheduleToStartTimeout, paramsB.StickyScheduleToStartTimeout)
 	require.Equal(t, paramsA.MaxConcurrentWorkflowTaskQueuePollers, paramsB.MaxConcurrentWorkflowTaskQueuePollers)

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -83,12 +83,6 @@ type (
 		// default: defaultMaxConcurrentTaskExecutionSize(1k)
 		MaxConcurrentWorkflowTaskExecutionSize int
 
-		// Optional: Sets the rate limiting on number of workflow tasks that can be executed per second per
-		// worker. This can be used to limit resources used by the worker.
-		// The zero value of this uses the default value.
-		// default: 100k
-		WorkerWorkflowTasksPerSecond float64
-
 		// Optional: Sets the maximum number of goroutines that will concurrently poll the
 		// temporal-server to retrieve workflow tasks. Changing this value will affect the
 		// rate at which the worker is able to consume tasks from a task queue.


### PR DESCRIPTION
Issue: This worker option throttles the rate at which we process tasks. Unfortunately, this option does not disambiguate between tasks received from the Worker's task queue and tasks received from the Global queue. As a result, a user setting this to a low value can have the unintended consequence of throttling the wrong type of tasks (throttling sticky tasks is bad since those are significantly cheaper to process as all the state needed to process the workflow task is already in memory).

Long-term, we should introduce two separate knobs (one for the Worker task queue and one for the Global task queue). For now, we will just have this not be configurable by the user and go with a default of 100,000.