### PR TITLE
Change client/server version support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/uber-go/tally v3.3.17+incompatible
 	github.com/uber/jaeger-client-go v2.23.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
-	go.temporal.io/api v0.31.0
+	go.temporal.io/api v0.31.1-0.20200925034343-222d8b5059fc
 	go.uber.org/atomic v1.6.0
 	go.uber.org/goleak v1.0.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/uber/jaeger-client-go v2.23.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMW
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.temporal.io/api v0.31.0 h1:aUcs7APtSLJYeq9YuB7hGO//KTWIlb8mblJyUPSEz40=
-go.temporal.io/api v0.31.0/go.mod h1:e1cHmNtmBsTHkeicHQeDs4GrWy9xsGIiXvWN53QAvq0=
+go.temporal.io/api v0.31.1-0.20200925034343-222d8b5059fc h1:zNNuMKrggMkf4Ufo/U+KyWzHxumNedPshffDCZFj1+8=
+go.temporal.io/api v0.31.1-0.20200925034343-222d8b5059fc/go.mod h1:PCs2TnEEYn03ClAuRO0qBHccIVPNbLJEwW+SrgKQShA=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/goleak v1.0.0 h1:qsup4IcBdlmsnGfqyLl4Ntn3C2XCCuKAE7DwHpScyUo=
@@ -120,8 +120,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200904194848-62affa334b73 h1:MXfv8rhZWmFeqX3GNZRsd6vOLoaCHjYEX3qkRo3YBUA=
-golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200923182212-328152dc79b1 h1:Iu68XRPd67wN4aRGGWwwq6bZo/25jR6uu52l/j2KkUE=
+golang.org/x/net v0.0.0-20200923182212-328152dc79b1/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -133,8 +133,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200917073148-efd3b9a0ff20 h1:4X356008q5SA3YXu8PiRap39KFmy4Lf6sGlceJKZQsU=
-golang.org/x/sys v0.0.0-20200917073148-efd3b9a0ff20/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d h1:L/IKR6COd7ubZrs2oTnTi73IhgqJ71c9s80WsQnh0Es=
+golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
@@ -165,8 +165,8 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20200917134801-bb4cff56e0d0 h1:uslsjIdqvZYANxSBQjTI47vZfwMaTN3mLELkMnMIY/A=
-google.golang.org/genproto v0.0.0-20200917134801-bb4cff56e0d0/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200925023002-c2d885f95484 h1:Rr9EZdYRq2WLckzJQVtN3ISKoP7dvgwi7jbglILNZ34=
+google.golang.org/genproto v0.0.0-20200925023002-c2d885f95484/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=

--- a/internal/client.go
+++ b/internal/client.go
@@ -534,7 +534,7 @@ func NewClient(options ClientOptions) (Client, error) {
 		options.Namespace = DefaultNamespace
 	}
 
-	options.MetricsScope = tagScope(options.MetricsScope, tagNamespace, options.Namespace, clientImplHeaderName, clientImplHeaderValue)
+	options.MetricsScope = tagScope(options.MetricsScope, tagNamespace, options.Namespace, clientNameHeaderName, clientNameHeaderValue)
 
 	if options.HostPort == "" {
 		options.HostPort = LocalHostPort
@@ -603,7 +603,7 @@ func NewServiceClient(workflowServiceClient workflowservice.WorkflowServiceClien
 
 // NewNamespaceClient creates an instance of a namespace client, to manager lifecycle of namespaces.
 func NewNamespaceClient(options ClientOptions) (NamespaceClient, error) {
-	options.MetricsScope = tagScope(options.MetricsScope, clientImplHeaderName, clientImplHeaderValue)
+	options.MetricsScope = tagScope(options.MetricsScope, clientNameHeaderName, clientNameHeaderValue)
 
 	if options.HostPort == "" {
 		options.HostPort = LocalHostPort

--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -42,15 +42,10 @@ import (
 )
 
 const (
-	// clientVersionHeaderName refers to the name of the gRPC metadata header that contains the client version.
-	clientVersionHeaderName = "temporal-client-version"
-
-	// clientFeatureVersionHeaderName refers to the name of the gRPC metadata header that contains the client feature set version.
-	clientFeatureVersionHeaderName = "temporal-client-feature-version"
-
-	// clientImplHeaderName refers to the name of the gRPC metadata header that contains the client implementation.
-	clientImplHeaderName  = "temporal-client-name"
-	clientImplHeaderValue = "temporal-go"
+	clientNameHeaderName              = "client-name"
+	clientNameHeaderValue             = "temporal-go"
+	clientVersionHeaderName           = "client-version"
+	supportedServerVersionsHeaderName = "supported-server-versions"
 
 	// defaultRPCTimeout is the default gRPC call timeout.
 	defaultRPCTimeout = 10 * time.Second
@@ -135,9 +130,9 @@ func newGRPCContext(ctx context.Context, options ...func(builder *grpcContextBui
 		ParentContext: ctx,
 		Timeout:       rpcTimeout,
 		Headers: metadata.New(map[string]string{
-			clientVersionHeaderName:        SDKVersion,
-			clientFeatureVersionHeaderName: SDKFeatureVersion,
-			clientImplHeaderName:           clientImplHeaderValue,
+			clientNameHeaderName:              clientNameHeaderValue,
+			clientVersionHeaderName:           SDKVersion,
+			supportedServerVersionsHeaderName: SupportedServerVersions,
 		}),
 	}
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -35,5 +35,5 @@ const (
 	// SupportedServerVersions is a semver rages (https://github.com/blang/semver#ranges) of server versions that
 	// are supported by this Temporal SDK.
 	// Server validates if its version fits into SupportedServerVersions range and rejects request if it doesn't.
-	SupportedServerVersions = ">=0.28.0 <2.0.0"
+	SupportedServerVersions = ">=0.31.0 <2.0.0"
 )

--- a/internal/version.go
+++ b/internal/version.go
@@ -24,16 +24,16 @@
 
 package internal
 
-// Below are the metadata which will be embedded as part of headers in every rpc call made by this client to Temporal server.
+// Below are the metadata which will be embedded as part of headers in every RPC call made by this client to Temporal server.
 // Update to the metadata below is typically done by the Temporal team as part of a major feature or behavior change.
 
-// SDKVersion is a semver that represents the version of this Temporal SDK.
-// This represents API changes visible to Temporal SDK consumers, i.e. developers
-// that are writing workflows. So every time we change API that can affect them we have to change this number.
-// Format: MAJOR.MINOR.PATCH
-const SDKVersion = "0.31.0"
+const (
+	// SDKVersion is a semver (https://semver.org/) that represents the version of this Temporal GoSDK.
+	// Server validates if SDKVersion fits its supported range and rejects request if it doesn't.
+	SDKVersion = "0.31.0"
 
-// SDKFeatureVersion is a semver that represents the feature set version of this Temporal SDK support.
-// This can be used for client capability check, on Temporal server, for backward compatibility.
-// Format: MAJOR.MINOR.PATCH
-const SDKFeatureVersion = "1.0.0"
+	// SupportedServerVersions is a semver rages (https://github.com/blang/semver#ranges) of server versions that
+	// are supported by this Temporal SDK.
+	// Server validates if its version fits into SupportedServerVersions range and rejects request if it doesn't.
+	SupportedServerVersions = ">=0.28.0 <2.0.0"
+)


### PR DESCRIPTION
Change GoSDK headers to match with upcoming server change. This change is backward compatible because both old and new servers accept client if headers are missing.