### PR TITLE
Initialize root scope with all rpc tags

### DIFF
--- a/internal/common/metrics/constants.go
+++ b/internal/common/metrics/constants.go
@@ -82,15 +82,12 @@ const (
 	WorkerTypeTagName       = "worker_type"
 	WorkflowTypeNameTagName = "workflow_type"
 	ActivityTypeNameTagName = "activity_type"
-	TypeTagName             = "type"
 	TaskQueueTagName        = "taskqueue"
 	OperationTagName        = "operation"
 )
 
 // Metric tag values
 const (
-	NoneTagValue            = "none"
-	RegularActivityTagValue = "regular"
-	LocalActivityTagValue   = "local"
-	ClientTagValue          = "temporal_go"
+	NoneTagValue   = "none"
+	ClientTagValue = "temporal_go"
 )

--- a/internal/common/metrics/request_scope.go
+++ b/internal/common/metrics/request_scope.go
@@ -77,5 +77,5 @@ func (rs *requestScope) recordEnd(err error) {
 func convertMethodToScope(method string) string {
 	// method is something like "/temporal.api.workflowservice.v1.WorkflowService/RegisterNamespace"
 	methodStart := strings.LastIndex(method, "/") + 1
-	return TemporalMetricsPrefix + method[methodStart:]
+	return method[methodStart:]
 }

--- a/internal/common/metrics/utils.go
+++ b/internal/common/metrics/utils.go
@@ -51,7 +51,9 @@ func TagScope(metricsScope tally.Scope, keyValuePairs ...string) tally.Scope {
 
 // GetRootScope return properly tagged tally scope with base tags included on all metric emitted by the client
 func GetRootScope(ts tally.Scope, namespace string) tally.Scope {
-	return TagScope(ts, NamespaceTagName, namespace, ClientTagName, ClientTagValue, WorkerTypeTagName, NoneTagValue)
+	// Include all tags on the root scope which are emitted by rpc calls to Temporal
+	return TagScope(ts, NamespaceTagName, namespace, ClientTagName, ClientTagValue, WorkerTypeTagName, NoneTagValue,
+		WorkflowTypeNameTagName, NoneTagValue, ActivityTypeNameTagName, NoneTagValue, TaskQueueTagName, NoneTagValue)
 }
 
 // GetWorkerScope return properly tagged tally scope worker type tag
@@ -59,21 +61,16 @@ func GetWorkerScope(ts tally.Scope, workerType string) tally.Scope {
 	return TagScope(ts, WorkerTypeTagName, workerType)
 }
 
-// GetEmptyRPCScope return properly tagged tally scope which can be used for any rpc call
-func GetEmptyRPCScope(ts tally.Scope) tally.Scope {
-	return GetMetricsScopeForRPC(ts, NoneTagValue, NoneTagValue, NoneTagValue)
-}
-
 // GetMetricsScopeForActivity return properly tagged tally scope for activity
 func GetMetricsScopeForActivity(ts tally.Scope, workflowType, activityType string) tally.Scope {
 	return TagScope(ts, WorkflowTypeNameTagName, workflowType, ActivityTypeNameTagName,
-		activityType, TypeTagName, RegularActivityTagValue)
+		activityType)
 }
 
 // GetMetricsScopeForLocalActivity return properly tagged tally scope for local activity
 func GetMetricsScopeForLocalActivity(ts tally.Scope, workflowType, localActivityType string) tally.Scope {
 	return TagScope(ts, WorkflowTypeNameTagName, workflowType, ActivityTypeNameTagName,
-		localActivityType, TypeTagName, LocalActivityTagValue)
+		localActivityType)
 }
 
 // GetMetricsScopeForWorkflow return properly tagged tally scope for workflow execution

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1876,7 +1876,7 @@ func recordActivityHeartbeat(
 	var heartbeatResponse *workflowservice.RecordActivityTaskHeartbeatResponse
 	heartbeatErr := backoff.Retry(ctx,
 		func() error {
-			grpcCtx, cancel := newGRPCContext(ctx, grpcMetricsScope(metrics.GetEmptyRPCScope(metricsScope)))
+			grpcCtx, cancel := newGRPCContext(ctx)
 			defer cancel()
 
 			var err error
@@ -1910,7 +1910,7 @@ func recordActivityHeartbeatByID(
 	var heartbeatResponse *workflowservice.RecordActivityTaskHeartbeatByIdResponse
 	heartbeatErr := backoff.Retry(ctx,
 		func() error {
-			grpcCtx, cancel := newGRPCContext(ctx, grpcMetricsScope(metrics.GetEmptyRPCScope(metricsScope)))
+			grpcCtx, cancel := newGRPCContext(ctx)
 			defer cancel()
 
 			var err error

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -203,8 +203,7 @@ func (bp *basePoller) doPoll(pollFunc func(ctx context.Context) (interface{}, er
 	var result interface{}
 
 	doneC := make(chan struct{})
-	ctx, cancel := newGRPCContext(context.Background(), grpcMetricsScope(metrics.GetEmptyRPCScope(bp.metricsScope)),
-		grpcTimeout(pollTaskServiceTimeOut), grpcLongPoll(true))
+	ctx, cancel := newGRPCContext(context.Background(), grpcTimeout(pollTaskServiceTimeOut), grpcLongPoll(true))
 
 	go func() {
 		result, err = pollFunc(ctx)
@@ -322,7 +321,7 @@ func (wtp *workflowTaskPoller) processWorkflowTask(task *workflowTask) error {
 }
 
 func (wtp *workflowTaskPoller) processResetStickinessTask(rst *resetStickinessTask) error {
-	grpcCtx, cancel := newGRPCContext(context.Background(), grpcMetricsScope(metrics.GetEmptyRPCScope(wtp.metricsScope)))
+	grpcCtx, cancel := newGRPCContext(context.Background())
 	defer cancel()
 	// WorkflowType information is not available on reset sticky task.  Emit using base scope.
 	wtp.metricsScope.Counter(metrics.StickyCacheTotalForcedEviction).Inc(1)

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -57,7 +57,6 @@ import (
 
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/internal/common/backoff"
-	"go.temporal.io/sdk/internal/common/metrics"
 	"go.temporal.io/sdk/internal/common/serializer"
 	"go.temporal.io/sdk/internal/common/util"
 	ilog "go.temporal.io/sdk/internal/log"
@@ -233,7 +232,7 @@ func ensureRequiredParams(params *workerExecutionParameters) {
 func verifyNamespaceExist(client workflowservice.WorkflowServiceClient, metricsScope tally.Scope, namespace string, logger log.Logger) error {
 	ctx := context.Background()
 	descNamespaceOp := func() error {
-		grpcCtx, cancel := newGRPCContext(ctx, grpcMetricsScope(metrics.GetEmptyRPCScope(metricsScope)))
+		grpcCtx, cancel := newGRPCContext(ctx)
 		defer cancel()
 		_, err := client.DescribeNamespace(grpcCtx, &workflowservice.DescribeNamespaceRequest{Name: namespace})
 		if err != nil {


### PR DESCRIPTION
Root scope is initialized with all tags needed for rpc calls.  This guarantees 
that any rpc invocation will have all same tags and now we don't have to 
explicitly initialize grpcContext with Empty rpc tags on each invocation.